### PR TITLE
Fix parse_setup_line arguments

### DIFF
--- a/cpython-macos/build.py
+++ b/cpython-macos/build.py
@@ -196,7 +196,7 @@ def python_build_info(python_path: pathlib.Path, config_c_in,
     # files.
 
     def process_setup_line(line):
-        d = parse_setup_line(line)
+        d = parse_setup_line(line, variant=None)
 
         if not d:
             return


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "python-build-standalone/cpython-macos/build.py", line 407, in <module>
    sys.exit(main())
  File "python-build-standalone/cpython-macos/build.py", line 399, in main
    build_cpython()
  File "python-build-standalone/cpython-macos/build.py", line 364, in build_cpython
    setup_local_content),
  File "python-build-standalone/cpython-macos/build.py", line 258, in python_build_info
    process_setup_line(line)
  File "python-build-standalone/cpython-macos/build.py", line 199, in process_setup_line
    d = parse_setup_line(line)
TypeError: parse_setup_line() missing 1 required positional argument: 'variant'
make: *** [python-build-standalone/build/cpython-macos.tar] Error 1
```