### PR TITLE
unix: fix PYBUILD_NO_DOCKER behaviour when Docker is available

### DIFF
--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -695,13 +695,13 @@ def main():
     DOWNLOADS_PATH.mkdir(exist_ok=True)
     (BUILD / "logs").mkdir(exist_ok=True)
 
-    try:
-        client = docker.from_env()
-        client.ping()
-    except Exception as e:
-        if os.environ.get("PYBUILD_NO_DOCKER"):
-            client = None
-        else:
+    if os.environ.get("PYBUILD_NO_DOCKER"):
+        client = None
+    else:
+        try:
+            client = docker.from_env()
+            client.ping()
+        except Exception as e:
             print("unable to connect to Docker: %s" % e)
             return 1
 


### PR DESCRIPTION
Previously, PYBUILD_NO_DOCKER would only allow failures connecting to
the Docker daemon. If it was available, this flag was ignored.

This finally lets me build on macOS (with Docker installed).