### PR TITLE
windows: Rename venv to venv.windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 build/
 dist/
-venv/

--- a/.hgignore
+++ b/.hgignore
@@ -1,3 +1,2 @@
 build/
 dist/
-venv/

--- a/build-windows.py
+++ b/build-windows.py
@@ -14,7 +14,7 @@ import venv
 ROOT = pathlib.Path(os.path.abspath(__file__)).parent
 BUILD = ROOT / "build"
 DIST = ROOT / "dist"
-VENV = BUILD / "venv"
+VENV = BUILD / "venv.windows"
 PIP = VENV / "Scripts" / "pip.exe"
 PYTHON = VENV / "Scripts" / "python.exe"
 REQUIREMENTS = ROOT / "requirements.win.txt"


### PR DESCRIPTION
Related to https://github.com/indygreg/python-build-standalone/issues/19