### PR TITLE
Use jom instead of nmake, for multi-core compile support.

### DIFF
--- a/pythonbuild/downloads.py
+++ b/pythonbuild/downloads.py
@@ -104,6 +104,12 @@ DOWNLOADS = {
         "sha256": "6b8b0fd7f81d0a957beb3679c81bbb34ccc7568d5682844d8924424a0dadcb1b",
         "version": "0.18",
     },
+    "jom-windows-bin": {
+        "url": "http://download.qt.io/official_releases/jom/jom_1_1_3.zip",
+        "size": 1213852,
+        "sha256": "128fdd846fe24f8594eed37d1d8929a0ea78df563537c0c1b1861a635013fff8",
+        "version": "1.1.3",
+    },
     "kbproto": {
         "url": "ftp://mirror.csclub.uwaterloo.ca/x.org/pub/current/src/proto/kbproto-1.0.7.tar.gz",
         "size": 325858,

--- a/pythonbuild/utils.py
+++ b/pythonbuild/utils.py
@@ -9,6 +9,7 @@ import pathlib
 import subprocess
 import sys
 import tarfile
+import zipfile
 import urllib.request
 
 import zstandard
@@ -163,6 +164,10 @@ def create_tar_from_directory(fh, base_path: pathlib.Path, path_prefix=None):
 def extract_tar_to_directory(source: pathlib.Path, dest: pathlib.Path):
     with tarfile.open(source, "r") as tf:
         tf.extractall(dest)
+
+def extract_zip_to_directory(source: pathlib.Path, dest: pathlib.Path):
+    with zipfile.ZipFile(source, "r") as zf:
+        zf.extractall(dest)
 
 
 def compress_python_archive(


### PR DESCRIPTION
[Jom](https://wiki.qt.io/Jom) is a drop-in replacement for MSVC's nmake with extra features like multi-core compile.

I've tried to use jom instead of nmake for openssl compile to use all machine cores, to greatly improve openssl compile time. Jom spawns one cl.exe process for each core, while nmake is always single-process and sequential, nmake creates only one cl.exe process simultaneously.

I've successfully built whole static python distro few days ago using this jom, and successfully built openssl stage today on latest repository state.