### PR TITLE
Add cross-builds for ARM

### DIFF
--- a/cpython-unix/base.Dockerfile
+++ b/cpython-unix/base.Dockerfile
@@ -1,6 +1,4 @@
-# Debian Jessie.
-FROM debian@sha256:734728c8e411698485ae644fc988dad06f757565e292b5b85edc084befa37bbb
-MAINTAINER Gregory Szorc <gregory.szorc@gmail.com>
+FROM ubuntu:xenial
 
 RUN groupadd -g 1000 build && \
     useradd -u 1000 -g 1000 -d /build -s /bin/bash -m build && \
@@ -17,10 +15,7 @@ ENV HOME=/build \
 CMD ["/bin/bash", "--login"]
 WORKDIR '/build'
 
-RUN for s in debian_jessie debian_jessie-updates debian-security_jessie/updates; do \
-      echo "deb http://snapshot.debian.org/archive/${s%_*}/20200510T203930Z/ ${s#*_} main"; \
-    done > /etc/apt/sources.list && \
-    ( echo 'quiet "true";'; \
+RUN ( echo 'quiet "true";'; \
       echo 'APT::Get::Assume-Yes "true";'; \
       echo 'APT::Install-Recommends "false";'; \
       echo 'Acquire::Check-Valid-Until "false";'; \

--- a/cpython-unix/build-bdb.sh
+++ b/cpython-unix/build-bdb.sh
@@ -15,7 +15,7 @@ pushd db-${BDB_VERSION}/build_unix
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ../dist/configure \
     --build=${BUILD_TRIPLE} \
-    --target=${TARGET_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \
     --enable-dbm \
     --disable-shared

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -250,13 +250,12 @@ fi
 
 if [ "${BUILD_TRIPLE}" != "${TARGET_TRIPLE}" ]; then
     CONFIGURE_FLAGS="--build=${BUILD_TRIPLE} \
-                    --host=${TARGET_TRIPLE} \
-                    --disable-ipv6 \
-                    ${CONFIGURE_FLAGS} \
-                    ac_cv_file__dev_ptmx=no \
-                    ac_cv_file__dev_ptc=no"
-    # Override sysconfig-provided project location during cross-builds.
-    export _PYTHON_PROJECT_BASE=$srcdir 
+                     --host=${TARGET_TRIPLE} \
+                     --disable-ipv6 \
+                     ${CONFIGURE_FLAGS} \
+                     ac_cv_file__dev_ptmx=no \
+                     ac_cv_file__dev_ptc=no"
+    export PYTHON_DECIMAL_WITH_MACHINE=uint128
 fi
 
 CFLAGS=$CFLAGS CPPFLAGS=$CFLAGS LDFLAGS=$LDFLAGS \
@@ -272,7 +271,7 @@ fi
 # Supplement produced Makefile with our modifications.
 cat ../Makefile.extra >> Makefile
 
-VERBOSE=1 make -j ${NUM_CPUS}
+make -j ${NUM_CPUS}
 make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out/python
 
 if [ "${PYTHON_MAJMIN_VERSION}" = "3.7" ]; then
@@ -288,8 +287,8 @@ else
 fi
 
 # Python interpreter to use during the build.
-if [ -z "${PYTHON_FOR_BUILD}" ]; then
-    PYTHON_FOR_BUILD=${ROOT}/out/python/install/bin/python3
+if [ -z "${BUILD_PYTHON}" ]; then
+    BUILD_PYTHON=${ROOT}/out/python/install/bin/python3
 fi
 
 # If we're building a shared library hack some binaries so rpath is set.
@@ -362,7 +361,7 @@ index ec9942f0..1b306ca7 100644
      except AttributeError:
 EOF
 
-${PYTHON_FOR_BUILD} setup.py install
+${BUILD_PYTHON} setup.py install
 popd
 
 pushd ${ROOT}/pip-${PIP_VERSION}
@@ -401,7 +400,7 @@ index 60a69d8..08c0597 100644
      except AttributeError:
 EOF
 
-${PYTHON_FOR_BUILD} setup.py install
+${BUILD_PYTHON} setup.py install
 popd
 
 # Emit metadata to be used in PYTHON.json.
@@ -444,7 +443,7 @@ with open(sys.argv[1], "w") as fh:
     json.dump(metadata, fh, sort_keys=True, indent=4)
 EOF
 
-${PYTHON_FOR_BUILD} ${ROOT}/generate_metadata.py ${ROOT}/metadata.json
+${BUILD_PYTHON} ${ROOT}/generate_metadata.py ${ROOT}/metadata.json
 cat ${ROOT}/metadata.json
 
 if [ "${CC}" != "musl-clang" ]; then

--- a/cpython-unix/build-gdbm.sh
+++ b/cpython-unix/build-gdbm.sh
@@ -15,9 +15,9 @@ pushd gdbm-${GDBM_VERSION}
 
 # CPython setup.py looks for libgdbm_compat and gdbm-ndbm.h,
 # which require --enable-libgdbm-compat.
-CLFAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+CLFAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_CFLAGS}" ./configure \
     --build=${BUILD_TRIPLE} \
-    --target=${TARGET_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \
     --disable-shared \
     --enable-libgdbm-compat

--- a/cpython-unix/build-gettext.sh
+++ b/cpython-unix/build-gettext.sh
@@ -17,7 +17,7 @@ pushd gettext-${GETTEXT_VERSION}
 # an added dependency. So we force use of the bundled version.
 CLFAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
     --build=${BUILD_TRIPLE} \
-    --target=${TARGET_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \
     --disable-shared \
     --disable-java \

--- a/cpython-unix/build-inputproto.sh
+++ b/cpython-unix/build-inputproto.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cd /build
+ROOT=`pwd`
 
 pkg-config --version
 
@@ -15,8 +15,10 @@ export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 tar -xf inputproto-${INPUTPROTO_VERSION}.tar.gz
 pushd inputproto-${INPUTPROTO_VERSION}
 
-CFLAGS="-fPIC" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-kbproto.sh
+++ b/cpython-unix/build-kbproto.sh
@@ -3,9 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-set -ex
-
-cd /build
+ROOT=`pwd`
 
 pkg-config --version
 
@@ -15,8 +13,10 @@ export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 tar -xf kbproto-${KBPROTO_VERSION}.tar.gz
 pushd kbproto-${KBPROTO_VERSION}
 
-CFLAGS="-fPIC" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-libX11.sh
+++ b/cpython-unix/build-libX11.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cd /build
+ROOT=`pwd`
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig:/tools/deps/lib/pkgconfig
@@ -41,9 +41,17 @@ if [ "${CC}" = "musl-clang" ]; then
     EXTRA_FLAGS="--disable-shared"
 fi
 
-CFLAGS="-fPIC -I/tools/deps/include" ./configure \
+if [ "${BUILD_TRIPLE}" != "${TARGET_TRIPLE}" ]; then
+    EXTRA_FLAGS="${EXTRA_FLAGS} \
+		--disable-ipv6 \
+		xorg_cv_malloc0_returns_null=yes"
+fi
+
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC -I/tools/deps/include" CFLAGS_FOR_BUILD="-I/tools/deps/include" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \
     ${EXTRA_FLAGS}
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-libXau.sh
+++ b/cpython-unix/build-libXau.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cd /build
+ROOT=`pwd`
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig:/tools/deps/lib/pkgconfig
@@ -17,9 +17,11 @@ if [ "${CC}" = "musl-clang" ]; then
     EXTRA_FLAGS="--disable-shared"
 fi
 
-CFLAGS="-fPIC" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \
     ${EXTRA_FLAGS}
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-libpthread-stubs.sh
+++ b/cpython-unix/build-libpthread-stubs.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cd /build
+ROOT=`pwd`
 
 pkg-config --version
 
@@ -15,8 +15,10 @@ export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 tar -xf libpthread-stubs-${LIBPTHREAD_STUBS_VERSION}.tar.gz
 pushd libpthread-stubs-${LIBPTHREAD_STUBS_VERSION}
 
-CFLAGS="-fPIC" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-libressl.sh
+++ b/cpython-unix/build-libressl.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cd /build
+ROOT=`pwd`
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 
@@ -21,4 +21,4 @@ CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./
     --disable-shared
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-libxcb.sh
+++ b/cpython-unix/build-libxcb.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cd /build
+ROOT=`pwd`
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig:/tools/deps/lib/pkgconfig
@@ -17,9 +17,14 @@ if [ "${CC}" = "musl-clang" ]; then
     EXTRA_FLAGS="--disable-shared"
 fi
 
-CFLAGS="-fPIC" ./configure \
+echo "############################################"
+echo "##### ${CC}"
+
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \
     ${EXTRA_FLAGS}
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-main.py
+++ b/cpython-unix/build-main.py
@@ -25,6 +25,8 @@ def main():
         targets = {
             default_target_triple,
             "x86_64-unknown-linux-musl",
+            "aarch64-unknown-linux-gnu",
+            "arm-unknown-linux-gnueabihf",
         }
     elif sys.platform == "darwin":
         host_platform = "macos"

--- a/cpython-unix/build-ncurses.sh
+++ b/cpython-unix/build-ncurses.sh
@@ -13,11 +13,27 @@ tar -xf ncurses-${NCURSES_VERSION}.tar.gz
 
 pushd ncurses-${NCURSES_VERSION}
 
+patch -p1 << 'EOF'
+diff --git a/configure b/configure
+--- a/configure
++++ b/configure
+@@ -15350,7 +15350,7 @@ echo "${ECHO_T}$with_stripping" >&6
+ 
+ if test "$with_stripping" = yes
+ then
+-	INSTALL_OPT_S="-s"
++	INSTALL_OPT_S="-s --strip-program=${STRIP}"
+ else
+ 	INSTALL_OPT_S=
+ fi
+EOF
+
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
     --build=${BUILD_TRIPLE} \
     --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \
     --without-cxx \
-    --enable-widec
+    --enable-widec \
+    --disable-db-install
 make -j ${NUM_CPUS}
 make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-openssl.sh
+++ b/cpython-unix/build-openssl.sh
@@ -25,11 +25,22 @@ fi
 
 if [ "${PYBUILD_PLATFORM}" = "macos" ]; then
   OPENSSL_TARGET=darwin64-x86_64-cc
-else
+elif [ "${TARGET_TRIPLE}" = "x86_64-unknown-linux-gnu" ]; then
   OPENSSL_TARGET=linux-x86_64
+elif [ "${TARGET_TRIPLE}" = "aarch64-unknown-linux-gnu" ]; then
+  OPENSSL_TARGET=linux-aarch64
+elif [ "${TARGET_TRIPLE}" = "arm-unknown-linux-gnueabihf" ]; then
+  OPENSSL_TARGET=linux-armv4
+else
+  echo "Error: unsupported target"
+  exit 1
 fi
 
-/usr/bin/perl ./Configure --prefix=/tools/deps ${OPENSSL_TARGET} no-shared ${EXTRA_FLAGS}
+CFLAGS="${EXTRA_TARGET_CFLAGS}" /usr/bin/perl ./Configure \
+    --prefix=/tools/deps \
+    ${OPENSSL_TARGET} \
+    no-shared \
+    ${EXTRA_FLAGS}
 
 make -j ${NUM_CPUS}
 make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-readline.sh
+++ b/cpython-unix/build-readline.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cd /build
+ROOT=`pwd`
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 
@@ -22,4 +22,4 @@ CLFAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LD
         --with-curses
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-sqlite.sh
+++ b/cpython-unix/build-sqlite.sh
@@ -12,7 +12,9 @@ export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 tar -xf sqlite-autoconf-${SQLITE_VERSION}.tar.gz
 pushd sqlite-autoconf-${SQLITE_VERSION}
 
-CFLAGS="-fPIC" CPPFLAGS="-fPIC" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="-fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix /tools/deps \
     --disable-shared
 

--- a/cpython-unix/build-tcl.sh
+++ b/cpython-unix/build-tcl.sh
@@ -40,6 +40,8 @@ if [ "${PYBUILD_PLATFORM}" = "macos" ]; then
 fi
 
 CFLAGS="${CFLAGS}" CPPFLAGS="${CFLAGS}" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \
     --enable-shared=no \
     --enable-threads

--- a/cpython-unix/build-tix.sh
+++ b/cpython-unix/build-tix.sh
@@ -33,7 +33,9 @@ fi
 
 # -DUSE_INTERP_RESULT is to allow tix to use deprecated fields or something
 # like that.
-CFLAGS="${CFLAGS}" CPPFLAGS="${CFLAGS}" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} ${CFLAGS}" CPPFLAGS="${EXTRA_TARGET_CFLAGS} ${CFLAGS}" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \
     --with-tcl=${TOOLS_PATH}/deps/lib \
     --with-tk=${TOOLS_PATH}/deps/lib \

--- a/cpython-unix/build-tk.sh
+++ b/cpython-unix/build-tk.sh
@@ -110,7 +110,9 @@ else
     EXTRA_CONFIGURE_FLAGS="--x-includes=${TOOLS_PATH}/deps/include --x-libraries=${TOOLS_PATH}/deps/lib"
 fi
 
-CFLAGS="${CFLAGS}" CPPFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} ${CFLAGS}" CPPFLAGS="${EXTRA_TARGET_CFLAGS} ${CFLAGS}" LDFLAGS="${LDFLAGS}" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \
     --with-tcl=${TOOLS_PATH}/deps/lib \
     --enable-shared=no \

--- a/cpython-unix/build-uuid.sh
+++ b/cpython-unix/build-uuid.sh
@@ -12,7 +12,9 @@ export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 tar -xf libuuid-${UUID_VERSION}.tar.gz
 pushd libuuid-${UUID_VERSION}
 
-CFLAGS="-fPIC" CPPFLAGS="-fPIC" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \
     --disable-shared
 

--- a/cpython-unix/build-x11-util-macros.sh
+++ b/cpython-unix/build-x11-util-macros.sh
@@ -5,14 +5,16 @@
 
 set -ex
 
-cd /build
+ROOT=`pwd`
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 
 tar -xzf util-macros-${X11_UTIL_MACROS_VERSION}.tar.gz
 pushd util-macros-${X11_UTIL_MACROS_VERSION}
-./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS}" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-xcb-proto.sh
+++ b/cpython-unix/build-xcb-proto.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cd /build
+ROOT=`pwd`
 
 pkg-config --version
 
@@ -15,8 +15,10 @@ export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 tar -xf xcb-proto-${XCB_PROTO_VERSION}.tar.gz
 pushd xcb-proto-${XCB_PROTO_VERSION}
 
-CFLAGS="-fPIC" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-xextproto.sh
+++ b/cpython-unix/build-xextproto.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cd /build
+ROOT=`pwd`
 
 pkg-config --version
 
@@ -15,8 +15,10 @@ export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 tar -xf xextproto-${XEXTPROTO_VERSION}.tar.gz
 pushd xextproto-${XEXTPROTO_VERSION}
 
-CFLAGS="-fPIC" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-xorgproto.sh
+++ b/cpython-unix/build-xorgproto.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cd /build
+ROOT=`pwd`
 
 pkg-config --version
 
@@ -15,8 +15,10 @@ export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 tar -xf xorgproto-${XORGPROTO_VERSION}.tar.gz
 pushd xorgproto-${XORGPROTO_VERSION}
 
-CFLAGS="-fPIC" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-xproto.sh
+++ b/cpython-unix/build-xproto.sh
@@ -15,7 +15,9 @@ export PKG_CONFIG_PATH=${TOOLS_PATH}/deps/share/pkgconfig
 tar -xf xproto-${XPROTO_VERSION}.tar.gz
 pushd xproto-${XPROTO_VERSION}
 
-CFLAGS="-fPIC" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps
 
 make -j ${NUM_CPUS}

--- a/cpython-unix/build-xtrans.sh
+++ b/cpython-unix/build-xtrans.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-cd /build
+ROOT=`pwd`
 
 pkg-config --version
 
@@ -15,8 +15,10 @@ export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 tar -xf xtrans-${XTRANS_VERSION}.tar.gz
 pushd xtrans-${XTRANS_VERSION}
 
-CFLAGS="-fPIC" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps
 
 make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j `nproc` install DESTDIR=${ROOT}/out

--- a/cpython-unix/build-xz.sh
+++ b/cpython-unix/build-xz.sh
@@ -14,6 +14,8 @@ tar -xf xz-${XZ_VERSION}.tar.gz
 pushd xz-${XZ_VERSION}
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CCASFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+    --build=${BUILD_TRIPLE} \
+    --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \
     --disable-shared \
     --disable-xz \

--- a/cpython-unix/build.Dockerfile
+++ b/cpython-unix/build.Dockerfile
@@ -10,3 +10,6 @@ RUN apt-get install \
     tar \
     xz-utils \
     unzip
+
+RUN apt-get install crossbuild-essential-arm64 &&\
+    apt-get install crossbuild-essential-armhf

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -741,7 +741,8 @@ def build_cpython(
 
         if cross_compiling(host_platform, target_triple):
             build_env.install_artifact_archive(BUILD, entry_name, "x86_64-unknown-linux-gnu", optimizations)
-            env["PYTHON_FOR_BUILD"] = "/tools/python/install/bin/python3"
+            env["PATH"] = "/tools/python/install/bin:{}".format(os.environ["PATH"])
+            env["BUILD_PYTHON"] = "python3"
 
         add_target_env(env, host_platform, target_triple, build_env)
 

--- a/cpython-unix/static-modules.3.7.linux64
+++ b/cpython-unix/static-modules.3.7.linux64
@@ -8,7 +8,7 @@ _crypt _cryptmodule.c -lcrypt
 _curses _cursesmodule.c -DHAVE_NCURSESW=1 -I/tools/deps/include/ncursesw -L/tools/deps/lib -lncursesw
 _curses_panel _curses_panel.c -DHAVE_NCURSESW=1 -I/tools/deps/include/ncursesw -L/tools/deps/lib -lpanelw -lncursesw
 _ctypes _ctypes/_ctypes.c _ctypes/callbacks.c _ctypes/callproc.c _ctypes/stgdict.c _ctypes/cfield.c -I/tools/deps/lib/libffi-3.2.1/include -lffi -ldl
-_decimal _decimal/_decimal.c _decimal/libmpdec/basearith.c _decimal/libmpdec/constants.c _decimal/libmpdec/context.c _decimal/libmpdec/convolute.c _decimal/libmpdec/crt.c _decimal/libmpdec/difradix2.c _decimal/libmpdec/fnt.c _decimal/libmpdec/fourstep.c _decimal/libmpdec/io.c _decimal/libmpdec/memory.c _decimal/libmpdec/mpdecimal.c _decimal/libmpdec/numbertheory.c _decimal/libmpdec/sixstep.c _decimal/libmpdec/transpose.c -DCONFIG_64=1 -DASM=1 -IModules/_decimal/libmpdec
+#_decimal _decimal/_decimal.c _decimal/libmpdec/basearith.c _decimal/libmpdec/constants.c _decimal/libmpdec/context.c _decimal/libmpdec/convolute.c _decimal/libmpdec/crt.c _decimal/libmpdec/difradix2.c _decimal/libmpdec/fnt.c _decimal/libmpdec/fourstep.c _decimal/libmpdec/io.c _decimal/libmpdec/memory.c _decimal/libmpdec/mpdecimal.c _decimal/libmpdec/numbertheory.c _decimal/libmpdec/sixstep.c _decimal/libmpdec/transpose.c -DCONFIG_64=1 -DASM=1 -IModules/_decimal/libmpdec
 _dbm _dbmmodule.c -DHAVE_BERKDB_H -DDB_DBM_HSEARCH -I/tools/deps/include -L/tools/deps/lib -ldb
 _elementtree _elementtree.c -DHAVE_EXPAT_CONFIG_H=1 -DXML_POOR_ENTROPY=1 -DUSE_PYEXPAT_CAPI -IModules/expat
 # Cannot build _gdbm due to use of bdb.

--- a/cpython-unix/static-modules.3.8.linux64
+++ b/cpython-unix/static-modules.3.8.linux64
@@ -8,7 +8,7 @@ _crypt _cryptmodule.c -lcrypt
 _curses _cursesmodule.c -DHAVE_NCURSESW=1 -I/tools/deps/include/ncursesw -L/tools/deps/lib -lncursesw
 _curses_panel _curses_panel.c -DHAVE_NCURSESW=1 -I/tools/deps/include/ncursesw -L/tools/deps/lib -lpanelw -lncursesw
 _ctypes _ctypes/_ctypes.c _ctypes/callbacks.c _ctypes/callproc.c _ctypes/stgdict.c _ctypes/cfield.c -I/tools/deps/lib/libffi-3.2.1/include -lffi -ldl
-_decimal _decimal/_decimal.c _decimal/libmpdec/basearith.c _decimal/libmpdec/constants.c _decimal/libmpdec/context.c _decimal/libmpdec/convolute.c _decimal/libmpdec/crt.c _decimal/libmpdec/difradix2.c _decimal/libmpdec/fnt.c _decimal/libmpdec/fourstep.c _decimal/libmpdec/io.c _decimal/libmpdec/memory.c _decimal/libmpdec/mpdecimal.c _decimal/libmpdec/numbertheory.c _decimal/libmpdec/sixstep.c _decimal/libmpdec/transpose.c -DCONFIG_64=1 -DASM=1 -IModules/_decimal/libmpdec
+#_decimal _decimal/_decimal.c _decimal/libmpdec/basearith.c _decimal/libmpdec/constants.c _decimal/libmpdec/context.c _decimal/libmpdec/convolute.c _decimal/libmpdec/crt.c _decimal/libmpdec/difradix2.c _decimal/libmpdec/fnt.c _decimal/libmpdec/fourstep.c _decimal/libmpdec/io.c _decimal/libmpdec/memory.c _decimal/libmpdec/mpdecimal.c _decimal/libmpdec/numbertheory.c _decimal/libmpdec/sixstep.c _decimal/libmpdec/transpose.c -IModules/_decimal/libmpdec
 _dbm _dbmmodule.c -DHAVE_BERKDB_H -DDB_DBM_HSEARCH -I/tools/deps/include -L/tools/deps/lib -ldb
 _elementtree _elementtree.c -DHAVE_EXPAT_CONFIG_H=1 -DXML_POOR_ENTROPY=1 -DUSE_PYEXPAT_CAPI -IModules/expat
 # Cannot build _gdbm due to use of bdb.


### PR DESCRIPTION
This enables cross-building for aarch64-unknown-linux-gnu and arm-unknown-linux-gnueabihf.
Because Python runs various scripts in the course of install image generation, a host arch Python distribution needs to be built first.

Areas that still need work:
- I've changed the base image to ubuntu:xenial, because it has cross-toolchains readily available.  Obviously, a Python distro built that way may not run on older Linuxes, e.g. CentOS 6 and the like.
- Not all Python tests pass.  But then they didn't seem to pass before my changes either.   Am I running tests the wrong way? -  
(`PYTHONHOME=$(pwd)/install LD_LIBRARY_PATH=$(pwd)/install/lib $(pwd)/install/bin/python3 build/run_tests.py` from the root of extracted zstd package).
- ~~I could not get the pip module to work on arm - `python3 -m ensurepip` fails because of missing _sysconfigdata__linux_aarch64-linux-gnu module.   Not sure why it isn't getting built...~~
