### PR TITLE
Fix Python extraction script

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -29,7 +29,7 @@ If you want to extract the distribution with Python, use the
 
 .. code-block:: python
 
-   import tar
+   import tarfile
    import zstandard
 
    with open("path/to/distribution.tar.zstd", "rb") as ifh:


### PR DESCRIPTION
I needed to import `tarfile` rather than `tar`.