### PR TITLE
ncurses: make build ABI-compatible with version 5

### DIFF
--- a/cpython-unix/build-ncurses.sh
+++ b/cpython-unix/build-ncurses.sh
@@ -62,6 +62,7 @@ if [ "${PYBUILD_PLATFORM}" = "macos" ]; then
     --sharedstatedir=/usr/com
     --with-terminfo-dirs=/usr/share/terminfo
     --with-default-terminfo-dir=/usr/share/terminfo
+    --with-abi-version=5
     --disable-db-install
   "
 fi


### PR DESCRIPTION
I built Mercurial on Mac with PyOxidizer. I then ran `hg commit -i` and quit without changing anything. That resulted in a segfault. It seems that the issue is an ABI compatibility between the ncurses version compiled against (6.1 or 6.2, I don't remember which) and the version dynamically linked on macOS. On Big Sur, the ncurses  version seems to be 5.4. Adding `--with-abi-version=5` to the `configure` script fixed the problem for me.