### PR TITLE
windows: restore windows 7 support

### DIFF
--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -1869,15 +1869,15 @@ def collect_python_build_artifacts(
         {"name": "shlwapi", "system": True},
         {"name": "version", "system": True},
         {"name": "ws2_32", "system": True},
-        # pathcch is Windows 8+ only. Python 3.9 dropped support for Windows 7.
-        # So this dependency is technically incorrect on Python 3.8.
-        {"name": "pathcch", "system": True},
         # In addition to the ones explicitly in the project, there are some
         # implicit link libraries not present. We list those as well.
         {"name": "Ole32", "system": True},
         {"name": "OleAut32", "system": True},
         {"name": "User32", "system": True},
     ]
+
+    if python_majmin in ["39", "310"]:
+        res["core"]["links"].append({"name": "pathcch", "system": True})
 
     # Copy files for extensions into their own directories.
     for ext in sorted(extension_projects):

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -75,11 +75,6 @@ Linux system.
 Windows
 -------
 
-Windows distributions require Windows 8 or Windows Server 2012 or newer. (The
-official Python distributions support Windows 7 up to Python 3.8 and dropped
-support for Windows 7 with Python 3.9. However, we've decided to drop
-support for Windows 7 from our Windows distributions.)
-
 Windows binaries have a dependency on the Microsoft Visual C++ Redistributable,
 likely from MSVC 2015 (``vcruntime140.dll``). This dependency is not
 provided in the distribution and will need to be provided by downstream


### PR DESCRIPTION
This restores windows 7 support just for Python 3.8 by making the `pathcch` library conditional.