### PR TITLE
fix: don't install openssl docs

### DIFF
--- a/cpython-unix/build-openssl.sh
+++ b/cpython-unix/build-openssl.sh
@@ -40,4 +40,4 @@ EXTRA_FLAGS="${EXTRA_FLAGS} ${EXTRA_TARGET_CFLAGS}"
 /usr/bin/perl ./Configure --prefix=/tools/deps ${OPENSSL_TARGET} no-shared no-tests ${EXTRA_FLAGS}
 
 make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j ${NUM_CPUS} install_sw install_ssldirs DESTDIR=${ROOT}/out


### PR DESCRIPTION
The installation of the openssl docs is incredibly long. The change set presented here avoids the installation of the docs.