### PR TITLE
Update Python 3.10 to 3.10.1

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -67,7 +67,7 @@ if [ "${BUILD_TRIPLE}" != "${TARGET_TRIPLE}" ]; then
 
   # Same patch as below. See comment there.
   if [ "${CC}" = "clang" ]; then
-    if [ "${PYTHON_MAJMIN_VERSION}" = "3.9" ]; then
+    if [ "${PYTHON_MAJMIN_VERSION}" = "3.9" ] || [ "${PYTHON_MAJMIN_VERSION}" = "3.10" ]; then
       patch -p1 <<"EOF"
 diff --git a/configure b/configure
 index 33ecb16f71..7f21822d97 100755
@@ -325,7 +325,7 @@ fi
 # configure. This is reported as https://bugs.python.org/issue45405. We nerf the
 # check since we know what we're doing.
 if [ "${CC}" = "clang" ]; then
-    if [ "${PYTHON_MAJMIN_VERSION}" = "3.9" ]; then
+    if [ "${PYTHON_MAJMIN_VERSION}" = "3.9" ] || [ "${PYTHON_MAJMIN_VERSION}" = "3.10" ]; then
         patch -p1 <<"EOF"
 diff --git a/configure b/configure
 index 33ecb16f71..7f21822d97 100755

--- a/pythonbuild/downloads.py
+++ b/pythonbuild/downloads.py
@@ -72,10 +72,10 @@ DOWNLOADS = {
     },
     # TODO remember to update windows shlwapi link annotation when we upgrade to 3.10.1.
     "cpython-3.10": {
-        "url": "https://www.python.org/ftp/python/3.10.0/Python-3.10.0.tar.xz",
-        "size": 18726176,
-        "sha256": "5a99f8e7a6a11a7b98b4e75e0d1303d3832cada5534068f69c7b6222a7b1b002",
-        "version": "3.10.0",
+        "url": "https://www.python.org/ftp/python/3.10.1/Python-3.10.1.tar.xz",
+        "size": 18775460,
+        "sha256": "a7f1265b6e1a5de1ec5c3ec7019ab53413469934758311e9d240c46e5ae6e177",
+        "version": "3.10.1",
         "licenses": ["Python-2.0", "CNRI-Python"],
         "license_file": "LICENSE.cpython.txt",
         "python_tag": "cp310",


### PR DESCRIPTION
Not sure what tests you typically run. It at least built fine on mac amd64/aarch4 and linux amd64/aarch64.

```
./build-macos.py --optimizations pgo --target-triple x86_64-apple-darwin --python cpython-3.10
./build-macos.py --target-triple aarch64-apple-darwin --python cpython-3.10

./build-linux.py --optimizations pgo --target x86_64-unknown-linux-gnu --python cpython-3.10
./build-linux.py --optimizations pgo --target aarch64-unknown-linux-gnu --python cpython-3.10
```

I have a bazel toolchains project with a python test suite I'll run against these builds and report back if they look ok.

I ran our test suite, which basically consists of
* `pip install pycryptodome==3.4.11` to confirm native extension compilation works
* checking `platform.python_version()` equals 3.10.1
* and some basic functionality tests of `multiprocessing`, `ctypes`, `uuid`, `lzma`, `socket`, `ssl`, and `asyncio`

All 4 interpreters passed. Can't validate the windows builds unfortunately and there's a TODO related to python 3.10.1 + windows I presume will need to be taken care of too.