### PR TITLE
unix: wrap sccache call with HAVE_SCCACHE

### DIFF
--- a/cpython-unix/build-gcc.sh
+++ b/cpython-unix/build-gcc.sh
@@ -58,4 +58,7 @@ make -j `nproc`
 make -j `nproc` install DESTDIR=/build/out
 popd
 
-sccache -s
+if [ -n "${HAVE_SCCACHE}" ]; then
+  sccache -s
+fi
+


### PR DESCRIPTION
Despite checking for the existence of sccache, there is a naked call to it not wrapped with the check for `HAVE_SCCACHE`, added the check