### PR TITLE
Fix zlib download URL

### DIFF
--- a/pythonbuild/downloads.py
+++ b/pythonbuild/downloads.py
@@ -398,7 +398,7 @@ DOWNLOADS = {
         "license_public_domain": True,
     },
     "zlib": {
-        "url": "https://zlib.net/zlib-1.2.11.tar.gz",
+        "url": "https://zlib.net/fossils/zlib-1.2.11.tar.gz",
         "size": 607698,
         "sha256": "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
         "version": "1.2.11",


### PR DESCRIPTION
zlib just released 1.2.12 on 03/22 and they only have the latest version available under zlib.net (so right now it's
https://www.zlib.net/zlib-1.2.12.tar.gz and https://www.zlib.net/zlib-1.2.11.tar.gz 404s and the Python build is broken.

However, they keep all versions (including the latest) under zlib.net/fossils so use that path instead.