### PR TITLE
unix: fix CLFAGS typo in some scripts.

### DIFF
--- a/cpython-unix/build-gdbm.sh
+++ b/cpython-unix/build-gdbm.sh
@@ -15,7 +15,7 @@ pushd gdbm-${GDBM_VERSION}
 
 # CPython setup.py looks for libgdbm_compat and gdbm-ndbm.h,
 # which require --enable-libgdbm-compat.
-CLFAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
     --build=${BUILD_TRIPLE} \
     --host=${TARGET_TRIPLE} \
     --prefix=/tools/deps \

--- a/cpython-unix/build-libedit.sh
+++ b/cpython-unix/build-libedit.sh
@@ -89,7 +89,7 @@ if [ "${CC}" = "musl-clang" ]; then
 fi
 
 # Install to /tools/deps/libedit so it doesn't conflict with readline's files.
-CLFAGS="${cflags}" CPPFLAGS="${cflags}" LDFLAGS="${ldflags}" \
+CFLAGS="${cflags}" CPPFLAGS="${cflags}" LDFLAGS="${ldflags}" \
     ./configure \
         --build=${BUILD_TRIPLE} \
         --host=${TARGET_TRIPLE} \

--- a/cpython-unix/build-patchelf.sh
+++ b/cpython-unix/build-patchelf.sh
@@ -13,7 +13,7 @@ tar -xf patchelf-${PATCHELF_VERSION}.tar.bz2
 
 pushd patchelf-0.12.20200827.8d3a16e
 
-CC="${HOST_CC}" CXX="${HOST_CXX}" CLFAGS="${EXTRA_HOST_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" \
+CC="${HOST_CC}" CXX="${HOST_CXX}" CFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" \
     ./configure \
         --build=${BUILD_TRIPLE} \
         --host=${TARGET_TRIPLE} \


### PR DESCRIPTION
We tried to build python with aarch64 and musl, but got failed in some packages.

These packages use CLFAGS while building and some substantial flags for musl-clang like `--target=aarch64-linux-musl` can not be read by configure scripts.

NOTE: fix may cause failed in some variants building.