### PR TITLE
Change mkfifoat and mknodat to be disabled unconditionally

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -387,12 +387,12 @@ if [ "${PYBUILD_PLATFORM}" = "macos" ]; then
                 CONFIGURE_FLAGS="${CONFIGURE_FLAGS} ac_cv_func_${symbol}=no"
             done
         fi
-
-        # mkfifoat, mknodat introduced in SDK 13.0.
-        for symbol in mkfifoat mknodat; do
-            CONFIGURE_FLAGS="${CONFIGURE_FLAGS} ac_cv_func_${symbol}=no"
-        done
     fi
+
+    # mkfifoat, mknodat are not introduced until SDK 13.0.
+    for symbol in mkfifoat mknodat; do
+        CONFIGURE_FLAGS="${CONFIGURE_FLAGS} ac_cv_func_${symbol}=no"
+    done
 
     if [ -n "${CROSS_COMPILING}" ]; then
         # Python's configure doesn't support cross-compiling on macOS. So we need


### PR DESCRIPTION
These two functions are currently disabled if using Python 3.8 or earlier, however even if you try to link the `libpython3.10.a` archive you get linker errors that these two symbols don't exist because the minimum deployment version was 11.0 and these don't exist until SDK 13.0.