### PR TITLE
Release s390x artifacts

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -106,6 +106,15 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
     );
 
     h.insert(
+        "s390x-unknown-linux-gnu",
+        TripleRelease {
+            suffixes: linux_suffixes_nopgo.clone(),
+            install_only_suffix: "lto",
+            python_version_requirement: None,
+        },
+    );
+    
+    h.insert(
         "i686-unknown-linux-gnu",
         TripleRelease {
             suffixes: linux_suffixes_pgo.clone(),


### PR DESCRIPTION
Support for s390x is already present in this repository added via https://github.com/indygreg/python-build-standalone/commit/7a0c31d3f365fed4a8f0e3125ce870c9afb07618 , however s390x artifacts are not released.
This PR is for enabling same. 
@indygreg Please let me know if anything more is needed.