### PR TITLE
Update the patchelf version: 0.12 -> 0.13.1 to fix corruption on s390x

### DIFF
--- a/cpython-unix/build-patchelf.sh
+++ b/cpython-unix/build-patchelf.sh
@@ -11,7 +11,7 @@ export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 
 tar -xf patchelf-${PATCHELF_VERSION}.tar.bz2
 
-pushd patchelf-0.12.20200827.8d3a16e
+pushd patchelf-0.13.1.20211127.72b6d44
 
 CC="${HOST_CC}" CXX="${HOST_CXX}" CFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" \
     ./configure \

--- a/pythonbuild/downloads.py
+++ b/pythonbuild/downloads.py
@@ -220,10 +220,10 @@ DOWNLOADS = {
         "version": "2.11.06",
     },
     "patchelf": {
-        "url": "https://github.com/NixOS/patchelf/releases/download/0.12/patchelf-0.12.tar.bz2",
-        "size": 165069,
-        "sha256": "699a31cf52211cf5ad6e35a8801eb637bc7f3c43117140426400d67b7babd792",
-        "version": "0.12",
+        "url": "https://github.com/NixOS/patchelf/releases/download/0.13.1/patchelf-0.13.1.tar.bz2",
+        "size": 173598,
+        "sha256": "39e8aeccd7495d54df094d2b4a7c08010ff7777036faaf24f28e07777d1598e2",
+        "version": "0.13.1",
     },
     "pip": {
         "url": "https://files.pythonhosted.org/packages/02/65/f15431ddee78562355ccb39097bf9160a1689f2db40dc418754be98806a1/pip-23.2-py3-none-any.whl",


### PR DESCRIPTION
downloads: patchelf 0.12 -> 0.13.1

patchelf 0.13.1 fixes a bug that caused the python3* executable to be corrupted on s390x. Attempting to run python3 on an s390x machine would produce an error like:

install/bin/python3: Permission denied

patchelf 0.13.1 is the most recent version that can be compiled by the debian stretch gcc since newer versions of patchelf require c++-17.

I have access to x86_64, s390x and ppc64le VMs so I did a quick build and smoke test of python 3.11 on those platforms and they looked good. I believe only the install/bin/python3* executables are processed by patchelf so I think my local testing should provide good coverage but let me know if there is anything specific I should try.