### PR TITLE
unix: enable tzset when x-compiling to linux target

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -95,8 +95,8 @@ jobs:
             type=registry,ref=ghcr.io/${{ env.REPO_NAME }}:${{ matrix.image }}-${{ env.GIT_REF_NAME }}
             type=registry,ref=ghcr.io/${{ env.REPO_NAME }}:${{ matrix.image }}-main
             type=registry,ref=ghcr.io/indygreg/python-build-standalone:${{ matrix.image }}-main
-          cache-to: |
-            type=registry,ref=ghcr.io/${{ env.REPO_NAME }}:${{ matrix.image }}-${{ env.GIT_REF_NAME }},ignore-errors=true
+          # cache-to: |
+          #   type=registry,ref=ghcr.io/${{ env.REPO_NAME }}:${{ matrix.image }}-${{ env.GIT_REF_NAME }},ignore-errors=true
           outputs: |
             type=docker,dest=build/image-${{ matrix.image }}.tar
 

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -438,6 +438,15 @@ if [ -n "${CROSS_COMPILING}" ]; then
     # The /dev/* check also fails for some reason.
     CONFIGURE_FLAGS="${CONFIGURE_FLAGS} ac_cv_file__dev_ptc=no"
     CONFIGURE_FLAGS="${CONFIGURE_FLAGS} ac_cv_file__dev_ptmx=no"
+
+    # When cross-compiling, configure cannot detect if the target system has a
+    # working tzset function in C. This influences whether or not the compiled
+    # python will end up with the time.tzset function or not. All linux targets,
+    # however, should have a working tzset function in C; so we manually
+    # indicate this to the configure script.
+    if [[ ${TARGET_TRIPLE} =~ .+-unknown-linux.* ]]; then
+        CONFIGURE_FLAGS="${CONFIGURE_FLAGS} ac_cv_working_tzset=yes"
+    fi
 fi
 
 CFLAGS=$CFLAGS CPPFLAGS=$CFLAGS LDFLAGS=$LDFLAGS \


### PR DESCRIPTION
When cross-compiling, `configure` cannot detect if the target system has a working `tzset` function in C. This influences whether or not the compiled python will end up with the `time.tzset` function or not, which is used by `django` and other important python projects. It would be nice to have access to `time.tzset` on `aarch64-unknown-linux-gnu`. 

Since all linux targets should have a working `tzset` function in C, we should be able to just manually indicate this to the configure script, which is what this PR does.

The motivation for this PR is as follows: Our organization uses the pre-built python interpreters from this project via `rules_python` and `bazel`.  We are currently migrating several `django` applications to `aarch64-unknown-linux-gnu` to take advantage of cheaper graviton instances on AWS and hit this issue. Accepting this PR would allow us to use this project's pre-built released interpreters instead of having to maintain our own fork and build our own interpreters. 

Fixes: #196