### PR TITLE
Fix "Cannot read termcap database;"

### DIFF
--- a/cpython-unix/build-ncurses.sh
+++ b/cpython-unix/build-ncurses.sh
@@ -20,7 +20,7 @@ if [[ -n "${CROSS_COMPILING}" && "${PYBUILD_PLATFORM}" != "macos" ]]; then
   echo "building host ncurses to provide modern tic for cross-compile"
 
   pushd ncurses-${NCURSES_VERSION}
-  CC="${HOST_CC}" ./configure --prefix=${TOOLS_PATH}/host --without-cxx --without-tests --without-manpages --enable-widec
+  CC="${HOST_CC}" ./configure --prefix=${TOOLS_PATH}/host --without-cxx --without-tests --without-manpages --enable-widec --with-terminfo-dirs=/usr/share/terminfo:/lib/terminfo
   make -j ${NUM_CPUS}
   make -j ${NUM_CPUS} install
 


### PR DESCRIPTION
./configure with defaults search path compatible with both FHS and the soon-to-be-deprecated Debian path

https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#idm236087499712

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1028202