### PR TITLE
Remove LTO-only builds when PGO+LTO exists

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -50,10 +50,6 @@ jobs:
           - target_triple: 'aarch64-apple-darwin'
             runner: macos-14
             py: 'cpython-3.8'
-            optimizations: 'lto'
-          - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
-            py: 'cpython-3.8'
             optimizations: 'pgo'
           - target_triple: 'aarch64-apple-darwin'
             runner: macos-14
@@ -67,10 +63,6 @@ jobs:
           - target_triple: 'aarch64-apple-darwin'
             runner: macos-14
             py: 'cpython-3.9'
-            optimizations: 'lto'
-          - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
-            py: 'cpython-3.9'
             optimizations: 'pgo'
           - target_triple: 'aarch64-apple-darwin'
             runner: macos-14
@@ -84,10 +76,6 @@ jobs:
           - target_triple: 'aarch64-apple-darwin'
             runner: macos-14
             py: 'cpython-3.10'
-            optimizations: 'lto'
-          - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
-            py: 'cpython-3.10'
             optimizations: 'pgo'
           - target_triple: 'aarch64-apple-darwin'
             runner: macos-14
@@ -101,10 +89,6 @@ jobs:
           - target_triple: 'aarch64-apple-darwin'
             runner: macos-14
             py: 'cpython-3.11'
-            optimizations: 'lto'
-          - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
-            py: 'cpython-3.11'
             optimizations: 'pgo'
           - target_triple: 'aarch64-apple-darwin'
             runner: macos-14
@@ -115,10 +99,6 @@ jobs:
             runner: macos-14
             py: 'cpython-3.12'
             optimizations: 'debug'
-          - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
-            py: 'cpython-3.12'
-            optimizations: 'lto'
           - target_triple: 'aarch64-apple-darwin'
             runner: macos-14
             py: 'cpython-3.12'
@@ -138,10 +118,6 @@ jobs:
           - target_triple: 'x86_64-apple-darwin'
             runner: macos-13
             py: 'cpython-3.8'
-            optimizations: 'lto'
-          - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
-            py: 'cpython-3.8'
             optimizations: 'pgo'
           - target_triple: 'x86_64-apple-darwin'
             runner: macos-13
@@ -155,10 +131,6 @@ jobs:
           - target_triple: 'x86_64-apple-darwin'
             runner: macos-13
             py: 'cpython-3.9'
-            optimizations: 'lto'
-          - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
-            py: 'cpython-3.9'
             optimizations: 'pgo'
           - target_triple: 'x86_64-apple-darwin'
             runner: macos-13
@@ -172,10 +144,6 @@ jobs:
           - target_triple: 'x86_64-apple-darwin'
             runner: macos-13
             py: 'cpython-3.10'
-            optimizations: 'lto'
-          - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
-            py: 'cpython-3.10'
             optimizations: 'pgo'
           - target_triple: 'x86_64-apple-darwin'
             runner: macos-13
@@ -189,10 +157,6 @@ jobs:
           - target_triple: 'x86_64-apple-darwin'
             runner: macos-13
             py: 'cpython-3.11'
-            optimizations: 'lto'
-          - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
-            py: 'cpython-3.11'
             optimizations: 'pgo'
           - target_triple: 'x86_64-apple-darwin'
             runner: macos-13
@@ -203,10 +167,6 @@ jobs:
             runner: macos-13
             py: 'cpython-3.12'
             optimizations: 'debug'
-          - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
-            py: 'cpython-3.12'
-            optimizations: 'lto'
           - target_triple: 'x86_64-apple-darwin'
             runner: macos-13
             py: 'cpython-3.12'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -422,10 +422,6 @@ jobs:
             run: true
           - target_triple: 'x86_64-unknown-linux-gnu'
             py: 'cpython-3.8'
-            optimizations: 'lto'
-            run: true
-          - target_triple: 'x86_64-unknown-linux-gnu'
-            py: 'cpython-3.8'
             optimizations: 'pgo'
             run: true
           - target_triple: 'x86_64-unknown-linux-gnu'
@@ -439,10 +435,6 @@ jobs:
             run: true
           - target_triple: 'x86_64-unknown-linux-gnu'
             py: 'cpython-3.9'
-            optimizations: 'lto'
-            run: true
-          - target_triple: 'x86_64-unknown-linux-gnu'
-            py: 'cpython-3.9'
             optimizations: 'pgo'
             run: true
           - target_triple: 'x86_64-unknown-linux-gnu'
@@ -456,10 +448,6 @@ jobs:
             run: true
           - target_triple: 'x86_64-unknown-linux-gnu'
             py: 'cpython-3.10'
-            optimizations: 'lto'
-            run: true
-          - target_triple: 'x86_64-unknown-linux-gnu'
-            py: 'cpython-3.10'
             optimizations: 'pgo'
             run: true
           - target_triple: 'x86_64-unknown-linux-gnu'
@@ -470,10 +458,6 @@ jobs:
           - target_triple: 'x86_64-unknown-linux-gnu'
             py: 'cpython-3.11'
             optimizations: 'debug'
-            run: true
-          - target_triple: 'x86_64-unknown-linux-gnu'
-            py: 'cpython-3.11'
-            optimizations: 'lto'
             run: true
           - target_triple: 'x86_64-unknown-linux-gnu'
             py: 'cpython-3.11'
@@ -490,10 +474,6 @@ jobs:
             run: true
           - target_triple: 'x86_64-unknown-linux-gnu'
             py: 'cpython-3.12'
-            optimizations: 'lto'
-            run: true
-          - target_triple: 'x86_64-unknown-linux-gnu'
-            py: 'cpython-3.12'
             optimizations: 'pgo'
             run: true
           - target_triple: 'x86_64-unknown-linux-gnu'
@@ -507,10 +487,6 @@ jobs:
             run: true
           - target_triple: 'x86_64_v2-unknown-linux-gnu'
             py: 'cpython-3.9'
-            optimizations: 'lto'
-            run: true
-          - target_triple: 'x86_64_v2-unknown-linux-gnu'
-            py: 'cpython-3.9'
             optimizations: 'pgo'
             run: true
           - target_triple: 'x86_64_v2-unknown-linux-gnu'
@@ -524,10 +500,6 @@ jobs:
             run: true
           - target_triple: 'x86_64_v2-unknown-linux-gnu'
             py: 'cpython-3.10'
-            optimizations: 'lto'
-            run: true
-          - target_triple: 'x86_64_v2-unknown-linux-gnu'
-            py: 'cpython-3.10'
             optimizations: 'pgo'
             run: true
           - target_triple: 'x86_64_v2-unknown-linux-gnu'
@@ -538,10 +510,6 @@ jobs:
           - target_triple: 'x86_64_v2-unknown-linux-gnu'
             py: 'cpython-3.11'
             optimizations: 'debug'
-            run: true
-          - target_triple: 'x86_64_v2-unknown-linux-gnu'
-            py: 'cpython-3.11'
-            optimizations: 'lto'
             run: true
           - target_triple: 'x86_64_v2-unknown-linux-gnu'
             py: 'cpython-3.11'
@@ -558,10 +526,6 @@ jobs:
             run: true
           - target_triple: 'x86_64_v2-unknown-linux-gnu'
             py: 'cpython-3.12'
-            optimizations: 'lto'
-            run: true
-          - target_triple: 'x86_64_v2-unknown-linux-gnu'
-            py: 'cpython-3.12'
             optimizations: 'pgo'
             run: true
           - target_triple: 'x86_64_v2-unknown-linux-gnu'
@@ -575,10 +539,6 @@ jobs:
             run: true
           - target_triple: 'x86_64_v3-unknown-linux-gnu'
             py: 'cpython-3.9'
-            optimizations: 'lto'
-            run: true
-          - target_triple: 'x86_64_v3-unknown-linux-gnu'
-            py: 'cpython-3.9'
             optimizations: 'pgo'
             run: true
           - target_triple: 'x86_64_v3-unknown-linux-gnu'
@@ -592,10 +552,6 @@ jobs:
             run: true
           - target_triple: 'x86_64_v3-unknown-linux-gnu'
             py: 'cpython-3.10'
-            optimizations: 'lto'
-            run: true
-          - target_triple: 'x86_64_v3-unknown-linux-gnu'
-            py: 'cpython-3.10'
             optimizations: 'pgo'
             run: true
           - target_triple: 'x86_64_v3-unknown-linux-gnu'
@@ -609,10 +565,6 @@ jobs:
             run: true
           - target_triple: 'x86_64_v3-unknown-linux-gnu'
             py: 'cpython-3.11'
-            optimizations: 'lto'
-            run: true
-          - target_triple: 'x86_64_v3-unknown-linux-gnu'
-            py: 'cpython-3.11'
             optimizations: 'pgo'
             run: true
           - target_triple: 'x86_64_v3-unknown-linux-gnu'
@@ -623,10 +575,6 @@ jobs:
           - target_triple: 'x86_64_v3-unknown-linux-gnu'
             py: 'cpython-3.12'
             optimizations: 'debug'
-            run: true
-          - target_triple: 'x86_64_v3-unknown-linux-gnu'
-            py: 'cpython-3.12'
-            optimizations: 'lto'
             run: true
           - target_triple: 'x86_64_v3-unknown-linux-gnu'
             py: 'cpython-3.12'

--- a/src/release.rs
+++ b/src/release.rs
@@ -28,7 +28,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
     let mut h = BTreeMap::new();
 
     // macOS.
-    let macos_suffixes = vec!["debug", "lto", "pgo", "pgo+lto"];
+    let macos_suffixes = vec!["debug", "pgo", "pgo+lto"];
     h.insert(
         "aarch64-apple-darwin",
         TripleRelease {
@@ -84,7 +84,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
     );
 
     // Linux.
-    let linux_suffixes_pgo = vec!["debug", "lto", "pgo", "pgo+lto"];
+    let linux_suffixes_pgo = vec!["debug", "pgo", "pgo+lto"];
     let linux_suffixes_nopgo = vec!["debug", "lto", "noopt"];
 
     h.insert(


### PR DESCRIPTION
## Summary

This PR removes `lto` builds for cases in which `pgo+lto` exists, which looked like a good first task to familiarize myself with the project structure.

Closes https://github.com/indygreg/python-build-standalone/issues/220.
