### PR TITLE
unix: use standard prefix for libedit

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -273,10 +273,6 @@ fi
 # Always build against libedit instead of the default of readline.
 # macOS always uses the system libedit, so no tweaks are needed.
 if [ "${PYBUILD_PLATFORM}" != "macos" ]; then
-    # On Linux, we need to add our custom libedit to search paths.
-    CFLAGS="${CFLAGS} -I${TOOLS_PATH}/deps/libedit/include"
-    LDFLAGS="${LDFLAGS} -L${TOOLS_PATH}/deps/libedit/lib"
-
     # CPython 3.10 introduced proper configure support for libedit, so add configure
     # flag there.
     if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_10}" ]; then
@@ -605,8 +601,6 @@ tools_path = os.environ["TOOLS_PATH"]
 replace_in_all("-I%s/deps/include/ncursesw" % tools_path, "")
 replace_in_all("-I%s/deps/include/uuid" % tools_path, "")
 replace_in_all("-I%s/deps/include" % tools_path, "")
-replace_in_all("-I%s/deps/libedit/include" % tools_path, "")
-replace_in_all("-L%s/deps/libedit/lib" % tools_path, "")
 replace_in_all("-L%s/deps/lib" % tools_path, "")
 
 EOF
@@ -855,10 +849,6 @@ done
 # library files as well.
 mkdir ${ROOT}/out/python/build/lib
 cp -av ${TOOLS_PATH}/deps/lib/*.a ${ROOT}/out/python/build/lib/
-
-if [ -d "${TOOLS_PATH}/deps/libedit" ]; then
-    cp -av ${TOOLS_PATH}/deps/libedit/lib/*.a ${ROOT}/out/python/build/lib/
-fi
 
 # On Apple, Python 3.9+ uses __builtin_available() to sniff for feature
 # availability. This symbol is defined by clang_rt, which isn't linked

--- a/cpython-unix/build-libedit.sh
+++ b/cpython-unix/build-libedit.sh
@@ -88,20 +88,19 @@ if [ "${CC}" = "musl-clang" ]; then
     cflags="${cflags} -D__STDC_ISO_10646__=201103L"
 fi
 
-# Install to /tools/deps/libedit so it doesn't conflict with readline's files.
 CFLAGS="${cflags}" CPPFLAGS="${cflags}" LDFLAGS="${ldflags}" \
     ./configure \
         --build=${BUILD_TRIPLE} \
         --host=${TARGET_TRIPLE} \
-        --prefix=/tools/deps/libedit \
+        --prefix=/tools/deps \
         --disable-shared
 
 make -j ${NUM_CPUS}
 make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
 
 # Alias readline/{history.h, readline.h} for readline compatibility.
-if [ -e ${ROOT}/out/tools/deps/libedit/include ]; then
-    mkdir ${ROOT}/out/tools/deps/libedit/include/readline
-    ln -s ../editline/readline.h ${ROOT}/out/tools/deps/libedit/include/readline/readline.h
-    ln -s ../editline/readline.h ${ROOT}/out/tools/deps/libedit/include/readline/history.h
+if [ -e ${ROOT}/out/tools/deps/include ]; then
+    mkdir ${ROOT}/out/tools/deps/include/readline
+    ln -s ../editline/readline.h ${ROOT}/out/tools/deps/include/readline/readline.h
+    ln -s ../editline/readline.h ${ROOT}/out/tools/deps/include/readline/history.h
 fi


### PR DESCRIPTION
Back in 2019 we made libedit's install prefix `/tools/deps/libedit` so we could have both readline and libedit installed side-by-side. This was all to support multiple extension module variants for `_readline` - one compiling against readline and another against libedit.

The extension module variants were removed in commit ba9fe19edec751e23f02f12a9c3ae7f928d22e08. But this one-off install prefix to support simultaneous readline and libedit presence still lingered.

This commit removes the one-off install prefix and makes libedit like every other dependency.