### PR TITLE
Remove Windows static builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,6 @@ jobs:
           - 'vcvars32.bat'
           - 'vcvars64.bat'
         profile:
-          - 'static-noopt'
           - 'shared-pgo'
     needs: pythonbuild
     runs-on: 'windows-2019'

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -92,15 +92,12 @@ If building CPython 3.8+, there are the following additional requirements:
 * An installation of Cywgin with the ``autoconf``, ``automake``, ``libtool``,
   and ``make`` packages installed. (``libffi`` build dependency.)
 
-To build a Python distribution for Windows x64::
+To build a dynamically linked Python distribution for Windows x64::
 
-   # From a Visual Studio 2017/2019 x64 native tools command prompt:
-   $ py.exe build-windows.py --profile static-noopt
+    $ py.exe build-windows.py --profile shared-noopt
 
-It is also possible to build a more traditional dynamically linked
-distribution, optionally with PGO optimizations::
+It's also possible to build with optional PGO optimizations::
 
-   $ py.exe build-windows.py --profile shared-noopt
    $ py.exe build-windows.py --profile shared-pgo
 
 If building CPython 3.8+, you will need to specify the path to a

--- a/src/release.rs
+++ b/src/release.rs
@@ -48,8 +48,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
 
     // Windows.
 
-    // The -shared and -static parts of the triple are a lie. But the code
-    // handles it fine.
+    // The -shared part of the triple is a lie. But the code handles it fine.
     h.insert(
         "i686-pc-windows-msvc-shared",
         TripleRelease {
@@ -59,26 +58,10 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         },
     );
     h.insert(
-        "i686-pc-windows-msvc-static",
-        TripleRelease {
-            suffixes: vec!["noopt"],
-            install_only_suffix: "noopt",
-            python_version_requirement: None,
-        },
-    );
-    h.insert(
         "x86_64-pc-windows-msvc-shared",
         TripleRelease {
             suffixes: vec!["pgo"],
             install_only_suffix: "pgo",
-            python_version_requirement: None,
-        },
-    );
-    h.insert(
-        "x86_64-pc-windows-msvc-static",
-        TripleRelease {
-            suffixes: vec!["noopt"],
-            install_only_suffix: "noopt",
             python_version_requirement: None,
         },
     );

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1633,8 +1633,7 @@ fn validate_distribution(
 
     let is_debug = dist_filename.contains("-debug-");
 
-    let is_static = triple.contains("unknown-linux-musl")
-        || (triple.contains("-windows-") && dist_path.to_string_lossy().contains("-static-"));
+    let is_static = triple.contains("unknown-linux-musl");
 
     let mut tf = crate::open_distribution_archive(&dist_path)?;
 


### PR DESCRIPTION
## Summary

This PR removes the Windows static builds from the build and release pipelines. As per https://github.com/indygreg/python-build-standalone/issues/221:

> The Windows static builds in this project are an artifact from trying to achieve the original goals of PyOxidizer. With the benefit of hindsight, the static Windows builds are borderline unusable.

Closes https://github.com/indygreg/python-build-standalone/issues/221.
