### PR TITLE
Upgrade armv7 builds to release

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -115,6 +115,24 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
     );
 
     h.insert(
+        "armv7-unknown-linux-gnueabi",
+        TripleRelease {
+            suffixes: linux_suffixes_nopgo.clone(),
+            install_only_suffix: "lto",
+            python_version_requirement: Some(VersionReq::parse(">=3.9").unwrap()),
+        },
+    );
+
+    h.insert(
+        "armv7-unknown-linux-gnueabihf",
+        TripleRelease {
+            suffixes: linux_suffixes_nopgo.clone(),
+            install_only_suffix: "lto",
+            python_version_requirement: Some(VersionReq::parse(">=3.9").unwrap()),
+        },
+    );
+
+    h.insert(
         "x86_64-unknown-linux-gnu",
         TripleRelease {
             suffixes: linux_suffixes_pgo.clone(),


### PR DESCRIPTION
## Summary

Upgrades `armv7-unknown-linux-gnueabi` and the hard-float variant `armv7-unknown-linux-gnueabihf` to be included in the release. These variants are already built, though they haven't been extensively tested as per the linked issue.

Closes https://github.com/indygreg/python-build-standalone/issues/203.