### PR TITLE
Allow building CPython from a local source directory

### DIFF
--- a/cpython-unix/Makefile
+++ b/cpython-unix/Makefile
@@ -17,6 +17,10 @@ ifndef PYBUILD_HOST_PLATFORM
     $(error PYBUILD_HOST_PLATFORM not defined)
 endif
 
+ifndef PYBUILD_PYTHON_SOURCE
+    $(error PYBUILD_PYTHON_SOURCE not defined)
+endif
+
 ifndef PYBUILD_PYTHON_VERSION
     $(error PYBUILD_PYTHON_VERSION not defined)
 endif
@@ -33,6 +37,7 @@ RUN_BUILD = $(BUILD) \
     --host-platform $(HOST_PLATFORM) \
     --target-triple $(TARGET_TRIPLE) \
     --optimizations $(PYBUILD_OPTIMIZATIONS) \
+    --python-source $(PYBUILD_PYTHON_SOURCE) \
     --dest-archive $@ \
     $(NULL)
 

--- a/cpython-unix/build-main.py
+++ b/cpython-unix/build-main.py
@@ -72,6 +72,11 @@ def main():
         help="Python distribution to build",
     )
     parser.add_argument(
+        "--python-source",
+        default=None,
+        help="A custom path to CPython source files to use",
+    )
+    parser.add_argument(
         "--break-on-failure",
         action="store_true",
         help="Enter a Python debugger if an error occurs",
@@ -118,6 +123,12 @@ def main():
         )
         return 1
 
+    python_source = (
+        (str(pathlib.Path(args.python_source).resolve()))
+        if args.python_source
+        else "null"
+    )
+
     musl = "musl" in target_triple
 
     env = dict(os.environ)
@@ -125,6 +136,7 @@ def main():
     env["PYBUILD_HOST_PLATFORM"] = host_platform
     env["PYBUILD_TARGET_TRIPLE"] = target_triple
     env["PYBUILD_OPTIMIZATIONS"] = args.optimizations
+    env["PYBUILD_PYTHON_SOURCE"] = python_source
     if musl:
         env["PYBUILD_MUSL"] = "1"
     if args.break_on_failure:
@@ -132,9 +144,16 @@ def main():
     if args.no_docker:
         env["PYBUILD_NO_DOCKER"] = "1"
 
-    entry = DOWNLOADS[args.python]
-    env["PYBUILD_PYTHON_VERSION"] = entry["version"]
-    env["PYBUILD_PYTHON_MAJOR_VERSION"] = ".".join(entry["version"].split(".")[0:2])
+    if not args.python_source:
+        entry = DOWNLOADS[args.python]
+        env["PYBUILD_PYTHON_VERSION"] = cpython_version = entry["version"]
+    else:
+        if "PYBUILD_PYTHON_VERSION" not in env:
+            print("PYBUILD_PYTHON_VERSION must be set when using `--python-source`")
+            return 1
+        cpython_version = env["PYBUILD_PYTHON_VERSION"]
+
+    env["PYBUILD_PYTHON_MAJOR_VERSION"] = ".".join(cpython_version.split(".")[0:2])
 
     if "PYBUILD_RELEASE_TAG" in os.environ:
         release_tag = os.environ["PYBUILD_RELEASE_TAG"]
@@ -142,7 +161,7 @@ def main():
         release_tag = release_tag_from_git()
 
     archive_components = [
-        "cpython-%s" % entry["version"],
+        "cpython-%s" % cpython_version,
         target_triple,
         args.optimizations,
     ]

--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -2656,6 +2656,7 @@ def main():
             "cpython-3.10",
             "cpython-3.11",
             "cpython-3.12",
+            "cpython-3.13",
         },
         default="cpython-3.11",
         help="Python distribution to build",

--- a/pythonbuild/buildenv.py
+++ b/pythonbuild/buildenv.py
@@ -38,9 +38,15 @@ class ContainerContext(object):
         dest_path = dest_path or "/build"
         copy_file_to_container(source, self.container, dest_path, dest_name)
 
-    def install_toolchain_archive(self, build_dir, package_name, host_platform):
+    def install_toolchain_archive(
+        self, build_dir, package_name, host_platform, version=None
+    ):
         entry = DOWNLOADS[package_name]
-        basename = "%s-%s-%s.tar" % (package_name, entry["version"], host_platform)
+        basename = "%s-%s-%s.tar" % (
+            package_name,
+            version or entry["version"],
+            host_platform,
+        )
 
         p = build_dir / basename
         self.copy_file(p)

--- a/pythonbuild/buildenv.py
+++ b/pythonbuild/buildenv.py
@@ -152,9 +152,15 @@ class TempdirContext(object):
         log("copying %s to %s/%s" % (source, dest_dir, dest_name))
         shutil.copy(source, dest_dir / dest_name)
 
-    def install_toolchain_archive(self, build_dir, package_name, host_platform):
+    def install_toolchain_archive(
+        self, build_dir, package_name, host_platform, version=None
+    ):
         entry = DOWNLOADS[package_name]
-        basename = "%s-%s-%s.tar" % (package_name, entry["version"], host_platform)
+        basename = "%s-%s-%s.tar" % (
+            package_name,
+            version or entry["version"],
+            host_platform,
+        )
 
         p = build_dir / basename
         dest_path = self.td / "tools"

--- a/pythonbuild/utils.py
+++ b/pythonbuild/utils.py
@@ -182,6 +182,17 @@ def write_package_versions(dest_path: pathlib.Path):
         write_if_different(p, content.encode("ascii"))
 
 
+def write_cpython_version(dest_path: pathlib.Path, version: str):
+    """Write a CPython version in a directory."""
+    dest_path.mkdir(parents=True, exist_ok=True)
+
+    major_minor = ".".join(version.split(".")[:2])
+    k = "cpython-%s" % major_minor
+    p = dest_path / ("VERSION.%s" % k)
+    content = "%s_VERSION := %s\n" % (k.upper().replace("-", "_"), version)
+    write_if_different(p, content.encode("ascii"))
+
+
 def write_target_settings(targets, dest_path: pathlib.Path):
     dest_path.mkdir(parents=True, exist_ok=True)
 
@@ -621,7 +632,7 @@ def release_download_statistics(mode="by_asset"):
             print("%d\t%s" % (count, build))
     elif mode == "by_tag":
         for tag, count in sorted(by_tag.items()):
-            print("%d\t%s"% (count, tag))
+            print("%d\t%s" % (count, tag))
     elif mode == "total":
         print("%d" % by_tag.total())
     else:


### PR DESCRIPTION
As a first step towards https://github.com/indygreg/python-build-standalone/issues/139, adds the ability to build from a local source directory instead of downloading CPython from `python.org` via a new `--python-source <path>` build option.

e.g. tested by cloning CPython at tag `v3.12.1` then building

```
PYBUILD_PYTHON_VERSION=3.12.1 python3.12 ./build-macos.py \
    --target-triple aarch64-apple-darwin \
    --python cpython-3.12 --optimizations debug \
    --python-source $(pwd)/../cpython
```

I also tested this with the latest commit on the CPython `3.12` branch.

There are a lot of assumptions about build information being available in the `DOWNLOADS` file, which makes this a little brittle. I also only implemented this for Unix.

I tried to make as minimal of a change as possible i.e. instead of refactoring to allow an unpacked source directory to be passed around we put the given source in an archive simulating a download. We could follow this with some more changes to abstract Python source downloads.

Additional safeguards could be added to avoid common mistakes, like ensuring that:

- The `PYBUILD_PYTHON_VERSION` version is compatible with the `--python` version
- The `--python-source` path exists
- Relative `--python-source` paths are resolved based on the original invocation working directory

Additionally, we could improve usability by:

- Inferring the `PYBUILD_PYTHON_VERSION` from the source files
- Allowing the source to be a remote path e.g. from GitHub
- Read commit information from Git and include in builds

Next steps for testing in-progress CPython builds would involve:

- Setting up a CI job to pull and build from Python 3.12's development branch
- Initial Python 3.13 support
- Similar changes to the Windows builds