### PR TITLE
Avoid incorrect triple match for substrings

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -204,7 +204,9 @@ pub async fn command_fetch_release_distributions(args: &ArgMatches) -> Result<()
 
             let name = zf.name().to_string();
 
-            if let Some((triple, release)) = RELEASE_TRIPLES.iter().find_map(|(triple, release)| {
+            // Iterate over `RELEASE_TRIPLES` in reverse-order to ensure that if any triple is a
+            // substring of another, the longest match is used.
+            if let Some((triple, release)) = RELEASE_TRIPLES.iter().rev().find_map(|(triple, release)| {
                 if name.contains(triple) {
                     Some((triple, release))
                 } else {


### PR DESCRIPTION
## Summary

Given an artifact like `cpython-3.8.19-x86_64-pc-windows-msvc-shared-pgo-20240401T1106.tar.gz`, we were matching against the triple `x86_64-pc-windows-msvc` (rather than `x86_64-pc-windows-msvc-shared`); so the release code then assumed that the install suffix was `shared-pgo` rather than `pgo`, and failed to align the assets.

This should fix _both_ of the issues described in #244, since the hard-float armv7 triples are _also_ prefixes of the non-hard-float variants (`armv7-unknown-linux-gnueabihf` vs. `armv7-unknown-linux-gnueabi`).

## Test Plan

Ran `just release` with these local changes (skipping uploads); verified that no missing-file errors were raised.
