### PR TITLE
running.rst: explain that install_only is based on the fastest build configuration

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -153,7 +153,9 @@ Common configurations include:
 The archive flavor denotes the content in the archive. See
 :ref:`distributions` for more. Casual users will likely want to use the
 ``install_only`` archive, as most users do not need the build artifacts
-present in the ``full`` archive.
+present in the ``full`` archive. The ``install_only`` archive doesn't
+include the build configuration in its file name. It's based on the fastest
+available build configuration for a given target.
 
 Extracting Distributions
 ========================


### PR DESCRIPTION
Today I downloaded an archive, after reading the Running Distribution docs, and had a bit of a hard time in deciding which archive I wanted, since the `install_only` archive file name doesn't have the build configuration name, so I wasn't sure which build configuration I got. Later I read the Distribution Archive doc and understood that it includes the fastest configuration. I think it's worthwhile to write this in the Running Distribution docs as well.

Thanks for your hard work!
Noam