### PR TITLE
Fix clippy lints

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -120,7 +120,7 @@ pub async fn command_fetch_release_distributions(args: &ArgMatches) -> Result<()
                     | ".github/workflows/linux.yml"
                     | ".github/workflows/windows.yml"
             ) {
-                workflow_names.insert(wf.id.clone(), wf.name);
+                workflow_names.insert(wf.id, wf.name);
 
                 Some(wf.id)
             } else {
@@ -263,7 +263,7 @@ pub async fn command_fetch_release_distributions(args: &ArgMatches) -> Result<()
                     .to_string_lossy()
             );
 
-            let dest_path = produce_install_only(&path)?;
+            let dest_path = produce_install_only(path)?;
 
             println!(
                 "releasing {}",
@@ -302,8 +302,7 @@ pub async fn command_upload_release_distributions(args: &ArgMatches) -> Result<(
         .expect("repo should be specified");
     let dry_run = args.get_flag("dry_run");
 
-    let mut filenames = std::fs::read_dir(&dist_dir)?
-        .into_iter()
+    let mut filenames = std::fs::read_dir(dist_dir)?
         .map(|x| {
             let path = x?.path();
             let filename = path

--- a/src/json.rs
+++ b/src/json.rs
@@ -108,7 +108,7 @@ impl PythonJsonMain {
 }
 
 pub fn parse_python_json(json_data: &[u8]) -> Result<PythonJsonMain> {
-    let v: PythonJsonMain = serde_json::from_slice(&json_data)?;
+    let v: PythonJsonMain = serde_json::from_slice(json_data)?;
 
     Ok(v)
 }

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -288,11 +288,8 @@ impl TbdMetadata {
             let stripped = symbols
                 .iter()
                 .filter_map(|x| {
-                    if let Some(stripped) = x.strip_prefix("R8289209$") {
-                        Some(stripped.to_string())
-                    } else {
-                        None
-                    }
+                    x.strip_prefix("R8289209$")
+                        .map(|stripped| stripped.to_string())
                 })
                 .collect::<Vec<_>>();
 
@@ -307,7 +304,7 @@ impl TbdMetadata {
 
         for (target, paths) in self.re_export_paths.iter_mut() {
             for path in paths.iter() {
-                let tbd_path = root_path.join(tbd_relative_path(&path)?);
+                let tbd_path = root_path.join(tbd_relative_path(path)?);
                 let tbd_info = TbdMetadata::from_path(&tbd_path)?;
 
                 if let Some(symbols) = tbd_info.symbols.get(target) {
@@ -409,10 +406,7 @@ impl IndexedSdks {
 
                         let empty = BTreeSet::new();
 
-                        let target_symbols = tbd_info
-                            .symbols
-                            .get(&symbol_target.to_string())
-                            .unwrap_or(&empty);
+                        let target_symbols = tbd_info.symbols.get(symbol_target).unwrap_or(&empty);
 
                         for (symbol, paths) in &symbols.symbols {
                             if !target_symbols.contains(symbol) {

--- a/src/release.rs
+++ b/src/release.rs
@@ -241,8 +241,7 @@ pub fn convert_to_install_only<W: Write>(reader: impl BufRead, writer: W) -> Res
         // increases the size of the archive and isn't needed in most cases.
         if path_bytes
             .windows(b"/libpython".len())
-            .position(|x| x == b"/libpython")
-            .is_some()
+            .any(|x| x == b"/libpython")
             && path_bytes.ends_with(b".a")
         {
             continue;
@@ -303,7 +302,7 @@ pub fn produce_install_only(tar_zst_path: &Path) -> Result<PathBuf> {
     let install_only_name = install_only_name.replace(".tar.zst", ".tar.gz");
 
     let dest_path = tar_zst_path.with_file_name(install_only_name);
-    std::fs::write(&dest_path, &gz_data)?;
+    std::fs::write(&dest_path, gz_data)?;
 
     Ok(dest_path)
 }


### PR DESCRIPTION
Updates the code to pass `cargo clippy`. Most of the fixes were auto-applied by Clippy.