### PR TITLE
Disable builds for branches that are not pull requests or `main`

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -2,6 +2,7 @@ name: MacOS Python build
 
 on:
   push:
+    branches: [main]
   pull_request:
   schedule:
     - cron: '13 11 * * *'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,7 @@ name: Linux Python build
 
 on:
   push:
+    branches: [main]
   pull_request:
   schedule:
     - cron: '13 11 * * *'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,6 +2,7 @@ name: Windows Python build
 
 on:
   push:
+    branches: [main]
   pull_request:
   schedule:
     - cron: '13 11 * * *'


### PR DESCRIPTION
Small change to save on build time since the workflows are so expensive to run.