### PR TITLE
Cancel in-flight builds on PR update

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
   schedule:
     - cron: '13 11 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   pythonbuild:
     runs-on: 'macos-13'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,9 +1,12 @@
-
 name: Check
 
 on:
   push:
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   check:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
   schedule:
     - cron: '13 11 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   pythonbuild:
     runs-on: ubuntu-22.04

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
   schedule:
     - cron: '13 11 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   pythonbuild:
     runs-on: 'windows-2019'


### PR DESCRIPTION
## Summary

I often manually cancel in-flight builds when I push a PR update. Borrowing this strategy from Ruff.