### PR TITLE
Create build directory when downloading LLVM

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -473,6 +473,7 @@ pub async fn bootstrap_llvm() -> Result<PathBuf> {
     let filename = url.path_segments().unwrap().last().unwrap();
 
     let llvm_dir = Path::new("build").join("llvm");
+    std::fs::create_dir_all(&llvm_dir)?;
 
     // If `llvm` is already available with the target version, return it.
     if llvm_dir.join(filename).exists() {


### PR DESCRIPTION
## Summary

I believe this will resolve the failure in: https://github.com/indygreg/python-build-standalone/actions/runs/10032748910/job/27724914285