### PR TITLE
Avoid duplicating `.tar.gz` suffix on stripped builds

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -440,7 +440,6 @@ pub fn produce_install_only_stripped(tar_gz_path: &Path, llvm_dir: &Path) -> Res
     name_parts[parts_len - 2] = "install_only_stripped".to_string();
 
     let install_only_name = name_parts.join("-");
-    let install_only_name = format!("{install_only_name}.tar.gz");
 
     let dest_path = tar_gz_path.with_file_name(install_only_name);
     std::fs::write(&dest_path, gz_data)?;


### PR DESCRIPTION
## Summary

Ran `cargo run convert-install-only-stripped cpython-3.8.19-i686-pc-windows-msvc-shared-install_only-20240725T1352.tar.gz`:

```
stripped /Users/crmarsh/workspace/python-build-standalone/cpython-3.8.19-i686-pc-windows-msvc-shared-install_only-20240725T1352.tar.gz from 17299450 to 17174780 bytes
wrote /Users/crmarsh/workspace/python-build-standalone/cpython-3.8.19-i686-pc-windows-msvc-shared-install_only_stripped-20240725T1352.tar.gz
```
