### PR TITLE
Stop bundling setuptools for Python 3.12+

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -576,7 +576,12 @@ fi
 # simply use our pip to install self. Kinda crazy, but it works!
 
 ${BUILD_PYTHON} "${PIP_WHEEL}/pip" install --prefix="${ROOT}/out/python/install" --no-cache-dir --no-index "${PIP_WHEEL}"
-${BUILD_PYTHON} "${PIP_WHEEL}/pip" install --prefix="${ROOT}/out/python/install" --no-cache-dir --no-index "${SETUPTOOLS_WHEEL}"
+
+# Setuptools is only installed for Python 3.11 and older, for parity with
+# `ensurepip` and `venv`: https://github.com/python/cpython/pull/101039
+if [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_11}" ]; then
+    ${BUILD_PYTHON} "${PIP_WHEEL}/pip" install --prefix="${ROOT}/out/python/install" --no-cache-dir --no-index "${SETUPTOOLS_WHEEL}"
+fi
 
 # Hack up the system configuration settings to aid portability.
 #

--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -19,6 +19,7 @@ import zipfile
 
 from pythonbuild.cpython import (
     STDLIB_TEST_PACKAGES,
+    meets_python_maximum_version,
     meets_python_minimum_version,
     parse_config_c,
 )
@@ -1653,19 +1654,22 @@ def build_cpython(
             pip_env,
         )
 
-        exec_and_log(
-            [
-                str(install_dir / "python.exe"),
-                "-m",
-                "pip",
-                "install",
-                "--no-cache-dir",
-                "--no-index",
-                str(setuptools_wheel),
-            ],
-            td,
-            pip_env,
-        )
+        # Setuptools is only installed for Python 3.11 and older, for parity with
+        # `ensurepip` and `venv`: https://github.com/python/cpython/pull/101039
+        if meets_python_maximum_version(python_version, "3.11"):
+            exec_and_log(
+                [
+                    str(install_dir / "python.exe"),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--no-cache-dir",
+                    "--no-index",
+                    str(setuptools_wheel),
+                ],
+                td,
+                pip_env,
+            )
 
         # The executables in the Scripts/ directory don't work because they reference
         # python.dll in the wrong path. You can run these via e.g. `python.exe -m pip`.

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -259,7 +259,7 @@ Extra Python Software
 Python installations have some additional software pre-installed:
 
 * `pip <https://pypi.org/project/pip/>`_
-* `setuptools <https://pypi.org/project/setuptools/>`_
+* `setuptools <https://pypi.org/project/setuptools/>`_ (for Python 3.11 and older)
 
 The intent of the pre-installed software is to facilitate end-user
 package installation without having to first bootstrap a packaging


### PR DESCRIPTION
For parity with the `ensurepip` and `venv` modules, which no longer install setuptools as of Python 3.12:
- https://github.com/python/cpython/issues/95299
- https://github.com/python/cpython/commit/ece20dba120a1a4745721c49f8d7389d4b1ee2a7

Fixes #300.