### PR TITLE
Ensure that deepfreeze.o is included in the distribution

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -830,7 +830,7 @@ ${BUILD_PYTHON} ${ROOT}/fix_shebangs.py ${ROOT}/out/python/install
 
 # Also copy object files so they can be linked in a custom manner by
 # downstream consumers.
-OBJECT_DIRS="Objects Parser Parser/pegen Programs Python"
+OBJECT_DIRS="Objects Parser Parser/pegen Programs Python Python/deepfreeze"
 OBJECT_DIRS="${OBJECT_DIRS} Modules"
 for ext in _blake2 cjkcodecs _ctypes _ctypes/darwin _decimal _expat _hacl _io _multiprocessing _sha3 _sqlite _sre _xxtestfuzz ; do
     OBJECT_DIRS="${OBJECT_DIRS} Modules/${ext}"


### PR DESCRIPTION
Python 3.11 and later create an object file in `Python/deepfreeze/deepfreeze.o` during compilation. This was not copied to the final `build` folder before packaging the distribution - now it is.

Fixes #156
