### PR TITLE
Ensure that Hacl_Hash_SHA2 does not appear as a library to link to

### DIFF
--- a/cpython-unix/extension-modules.yml
+++ b/cpython-unix/extension-modules.yml
@@ -411,17 +411,12 @@ _sha2:
   minimum-python-version: "3.12"
   sources:
     - sha2module.c
+    - _hacl/Hacl_Hash_SHA2.c
   includes:
     - Modules/_hacl/include
-    - Modules/_hacl/internal
   defines:
     - _BSD_SOURCE
     - _DEFAULT_SOURCE
-  links:
-    # Use the colon syntax to prevent the library dependency from getting
-    # recorded in JSON metadata. This relies on setting up a linker library
-    # path (-L) in LDFLAGS.
-    - ":libHacl_Hash_SHA2.a"
 
 _sha3:
   sources-conditional:


### PR DESCRIPTION
When trying to update PyOxidizer and PyOxy to support standalone builds of Python 3.12, I noticed that the build attempted to link to a library named `Hacl_Hash_SHA2` when `pyoxy` was linked (with `-lHacl_Hash_SHA2`). This PR fixes the metadata in `PYTHON.json`.