### PR TITLE
Add link to docs in contributing guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,6 +2,12 @@
 Contributing
 ============
 
+Building distributions
+======================
+
+See the [documentation](https://gregoryszorc.com/docs/python-build-standalone/main/building.html)
+for instructions on building distributions locally.
+
 Releases
 ========
 


### PR DESCRIPTION
Otherwise, it's not clear how to get to this when looking to contribute.