### PR TITLE
Print to stderr when unable to connect to Docker

### DIFF
--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -909,7 +909,7 @@ def main():
             client = docker.from_env()
             client.ping()
         except Exception as e:
-            print("unable to connect to Docker: %s" % e)
+            print("unable to connect to Docker: %s" % e, file=sys.stderr)
             return 1
 
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Instead of failing with the inscrutable:

```
Makefile:49: *** multiple target patterns.  Stop.
```

We fail with the actual error:

```
unable to connect to Docker: Error while fetching server API version: ('Connection aborted.', ConnectionRefusedError(111, 'Connection refused'))
unable to connect to Docker: Error while fetching server API version: ('Connection aborted.', ConnectionRefusedError(111, 'Connection refused'))
/big/workspace/python-build-standalone/cpython-unix/build.py --host-platform linux64 --target-triple x86_64-unknown-linux-gnu --optimizations pgo --python-source null --dest-archive /big/workspace/python-build-standalone/build/image-build.tar  --toolchain image-build
/big/workspace/python-build-standalone/cpython-unix/build.py --host-platform linux64 --target-triple x86_64-unknown-linux-gnu --optimizations pgo --python-source null --dest-archive /big/workspace/python-build-standalone/build/image-gcc.tar  --toolchain image-gcc
/big/workspace/python-build-standalone/cpython-unix/build.py --host-platform linux64 --target-triple x86_64-unknown-linux-gnu --optimizations pgo --python-source null --dest-archive /big/workspace/python-build-standalone/build/llvm-18-x86_64-linux-18.0.8+20240713-linux64.tar  --toolchain clang --target-triple x86_64-unknown-linux-gnu
/big/workspace/python-build-standalone/cpython-unix/build.py --host-platform linux64 --target-triple x86_64-unknown-linux-gnu --optimizations pgo --python-source null --dest-archive /big/workspace/python-build-standalone/build/image-xcb.tar  --toolchain image-xcb
unable to connect to Docker: Error while fetching server API version: ('Connection aborted.', ConnectionRefusedError(111, 'Connection refused'))unable to connect to Docker: Error while fetching server API version: ('Connection aborted.', ConnectionRefusedError(111, 'Connection refused'))

unable to connect to Docker: Error while fetching server API version: ('Connection aborted.', ConnectionRefusedError(111, 'Connection refused'))
unable to connect to Docker: Error while fetching server API version: ('Connection aborted.', ConnectionRefusedError(111, 'Connection refused'))
make: *** [Makefile:83: /big/workspace/python-build-standalone/build/llvm-18-x86_64-linux-18.0.8+20240713-linux64.tar] Error 1
make: *** Waiting for unfinished jobs....
make: *** [Makefile:76: /big/workspace/python-build-standalone/build/image-gcc.tar] Error 1
make: *** [Makefile:76: /big/workspace/python-build-standalone/build/image-xcb.tar] Error 1
make: *** [Makefile:76: /big/workspace/python-build-standalone/build/image-build.tar] Error 1
```