### PR TITLE
Remove custom Rust toolchain installation

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -17,11 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Emit rustc version
         run: |
           rustc --version > .rustc-version

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,11 +22,6 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Emit rustc version
         run: |
           rustc --version > .rustc-version

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,11 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Emit rustc version
         run: |
           rustc --version > .rustc-version


### PR DESCRIPTION
These should all come pre-installed on GitHub runners now so we can save some CI time (~20s on Windows, ~13s on macOS).

I'm not sure if there's some other benefit to using the toolchain action, but we don't over in astral-sh/uv.
