### PR TITLE
Switch from `semver::Version` to `pep440_rs::Version` for Python version comparisons during release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,6 +1243,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pep440_rs"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "466eada3179c2e069ca897b99006cbb33f816290eaeec62464eea907e22ae385"
+dependencies = [
+ "once_cell",
+ "unicode-width",
+ "unscanny",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,6 +1354,7 @@ dependencies = [
  "octocrab",
  "once_cell",
  "pdb",
+ "pep440_rs",
  "rayon",
  "reqwest",
  "scroll 0.12.0",
@@ -2187,10 +2199,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+
+[[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ object = "0.32.2"
 octocrab = { version = "0.34.1", features = ["rustls", "stream"] }
 once_cell = "1.19.0"
 pdb = "0.8.0"
+pep440_rs = "0.6.6"
 rayon = "1.8.1"
 reqwest = { version = "0.11.24", features = ["rustls", "stream"] }
 scroll = "0.12.0"

--- a/src/github.rs
+++ b/src/github.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::str::FromStr;
+
 use crate::release::{bootstrap_llvm, produce_install_only_stripped};
 use {
     crate::release::{produce_install_only, RELEASE_TRIPLES},
@@ -355,8 +357,8 @@ pub async fn command_upload_release_distributions(args: &ArgMatches) -> Result<(
     for version in python_versions {
         for (triple, release) in RELEASE_TRIPLES.iter() {
             if let Some(req) = &release.python_version_requirement {
-                let python_version = semver::Version::parse(version)?;
-                if !req.matches(&python_version) {
+                let python_version = pep440_rs::Version::from_str(version)?;
+                if !req.contains(&python_version) {
                     continue;
                 }
             }

--- a/src/release.rs
+++ b/src/release.rs
@@ -6,13 +6,16 @@ use anyhow::Context;
 use futures::StreamExt;
 
 use object::FileKind;
-use std::process::{Command, Stdio};
+use std::{
+    process::{Command, Stdio},
+    str::FromStr,
+};
 use url::Url;
 use {
     crate::json::parse_python_json,
     anyhow::{anyhow, Result},
     once_cell::sync::Lazy,
-    semver::VersionReq,
+    pep440_rs::VersionSpecifier,
     std::{
         collections::BTreeMap,
         io::{BufRead, Read, Write},
@@ -27,7 +30,7 @@ pub struct TripleRelease {
     /// Build suffix to use for the `install_only` artifact.
     pub install_only_suffix: &'static str,
     /// Minimum Python version this triple is released for.
-    pub python_version_requirement: Option<VersionReq>,
+    pub python_version_requirement: Option<VersionSpecifier>,
 }
 
 pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::new(|| {
@@ -107,7 +110,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),
             install_only_suffix: "lto",
-            python_version_requirement: Some(VersionReq::parse(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
         },
     );
 
@@ -116,7 +119,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),
             install_only_suffix: "lto",
-            python_version_requirement: Some(VersionReq::parse(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
         },
     );
 
@@ -125,7 +128,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),
             install_only_suffix: "lto",
-            python_version_requirement: Some(VersionReq::parse(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
         },
     );
 
@@ -134,7 +137,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),
             install_only_suffix: "lto",
-            python_version_requirement: Some(VersionReq::parse(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
         },
     );
 
@@ -151,7 +154,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_pgo.clone(),
             install_only_suffix: "pgo+lto",
-            python_version_requirement: Some(VersionReq::parse(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
         },
     );
     h.insert(
@@ -159,7 +162,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_pgo.clone(),
             install_only_suffix: "pgo+lto",
-            python_version_requirement: Some(VersionReq::parse(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
         },
     );
     h.insert(
@@ -167,7 +170,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),
             install_only_suffix: "lto",
-            python_version_requirement: Some(VersionReq::parse(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
         },
     );
     h.insert(
@@ -183,7 +186,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),
             install_only_suffix: "lto",
-            python_version_requirement: Some(VersionReq::parse(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
         },
     );
     h.insert(
@@ -191,7 +194,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),
             install_only_suffix: "lto",
-            python_version_requirement: Some(VersionReq::parse(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
         },
     );
     h.insert(
@@ -199,7 +202,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
         TripleRelease {
             suffixes: linux_suffixes_nopgo.clone(),
             install_only_suffix: "lto",
-            python_version_requirement: Some(VersionReq::parse(">=3.9").unwrap()),
+            python_version_requirement: Some(VersionSpecifier::from_str(">=3.9").unwrap()),
         },
     );
 


### PR DESCRIPTION
Otherwise, we fail to parse `3.13.0rc2` because the Python prerelease syntax does not match the Cargo SemVer syntax
