### PR TITLE
Drop Python 3.8 builds from CI

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -46,19 +46,6 @@ jobs:
         build:
           - target_triple: 'aarch64-apple-darwin'
             runner: macos-14
-            py: 'cpython-3.8'
-            options: 'debug'
-          - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
-            py: 'cpython-3.8'
-            options: 'pgo'
-          - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
-            py: 'cpython-3.8'
-            options: 'pgo+lto'
-
-          - target_triple: 'aarch64-apple-darwin'
-            runner: macos-14
             py: 'cpython-3.9'
             options: 'debug'
           - target_triple: 'aarch64-apple-darwin'
@@ -138,19 +125,6 @@ jobs:
           # macOS on Intel hardware. This is pretty straightforward. We exclude
           # noopt because it doesn't provide any compelling advantages over PGO
           # or LTO builds.
-          - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
-            py: 'cpython-3.8'
-            options: 'debug'
-          - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
-            py: 'cpython-3.8'
-            options: 'pgo'
-          - target_triple: 'x86_64-apple-darwin'
-            runner: macos-13
-            py: 'cpython-3.8'
-            options: 'pgo+lto'
-
           - target_triple: 'x86_64-apple-darwin'
             runner: macos-13
             py: 'cpython-3.9'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -120,15 +120,6 @@ jobs:
       matrix:
         build:
           # Cross-compiles can't do PGO.
-          - target_triple: 'aarch64-unknown-linux-gnu'
-            py: 'cpython-3.8'
-            options: 'debug'
-          - target_triple: 'aarch64-unknown-linux-gnu'
-            py: 'cpython-3.8'
-            options: 'noopt'
-          - target_triple: 'aarch64-unknown-linux-gnu'
-            py: 'cpython-3.8'
-            options: 'lto'
 
           - target_triple: 'aarch64-unknown-linux-gnu'
             py: 'cpython-3.9'
@@ -415,20 +406,6 @@ jobs:
           - target_triple: 'ppc64le-unknown-linux-gnu'
             py: 'cpython-3.12'
             options: 'lto'
-
-          # We don't publish noopt builds when PGO is available.
-          - target_triple: 'x86_64-unknown-linux-gnu'
-            py: 'cpython-3.8'
-            options: 'debug'
-            run: true
-          - target_triple: 'x86_64-unknown-linux-gnu'
-            py: 'cpython-3.8'
-            options: 'pgo'
-            run: true
-          - target_triple: 'x86_64-unknown-linux-gnu'
-            py: 'cpython-3.8'
-            options: 'pgo+lto'
-            run: true
 
           - target_triple: 'x86_64-unknown-linux-gnu'
             py: 'cpython-3.9'
@@ -629,18 +606,6 @@ jobs:
             options: 'lto'
 
           # musl doesn't support PGO.
-          - target_triple: 'x86_64-unknown-linux-musl'
-            py: 'cpython-3.8'
-            options: 'debug'
-            run: true
-          - target_triple: 'x86_64-unknown-linux-musl'
-            py: 'cpython-3.8'
-            options: 'noopt'
-            run: true
-          - target_triple: 'x86_64-unknown-linux-musl'
-            py: 'cpython-3.8'
-            options: 'lto'
-            run: true
 
           - target_triple: 'x86_64-unknown-linux-musl'
             py: 'cpython-3.9'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,7 +44,6 @@ jobs:
       fail-fast: false
       matrix:
         py:
-          - 'cpython-3.8'
           - 'cpython-3.9'
           - 'cpython-3.10'
           - 'cpython-3.11'


### PR DESCRIPTION
This does not remove the ability to build 3.8, which I see as less pressing than removing the jobs from CI since the matrix is so big
