### PR TITLE
Add sccache to `pythonbuild`

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -14,8 +14,14 @@ concurrency:
 jobs:
   pythonbuild:
     runs-on: 'macos-13'
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Emit rustc version
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,6 +14,9 @@ concurrency:
 jobs:
   pythonbuild:
     runs-on: ubuntu-22.04
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - name: Install System Dependencies
         run: |
@@ -21,6 +24,9 @@ jobs:
           sudo apt install -y --no-install-recommends libssl-dev pkg-config
 
       - uses: actions/checkout@v4
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Emit rustc version
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,8 +14,14 @@ concurrency:
 jobs:
   pythonbuild:
     runs-on: 'windows-2019'
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Emit rustc version
         run: |


### PR DESCRIPTION
I was looking at adding this to the actual cpython build, but it looks a bit more complex. I'm not sure how to pass `CC` and `CXX` to make [as required by the docs](https://github.com/Mozilla-Actions/sccache-action?tab=readme-ov-file#cc-code), and `build-cpython.sh` seems to do some checks that could interfere with this:

https://github.com/indygreg/python-build-standalone/blob/78e57bd18b48c357904b47a6ae6999ebb255c578/cpython-unix/build-cpython.sh#L119