### PR TITLE
Disable cron for forks

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   pythonbuild:
+    if: ${{ github.repository_owner == 'indygreg' || github.event_name != 'schedule' }}
     runs-on: 'macos-13'
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +41,7 @@ jobs:
           path: target/release/pythonbuild
 
   build:
+    if: ${{ github.repository_owner == 'indygreg' || github.event_name != 'schedule' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   pythonbuild:
+    if: ${{ github.repository_owner == 'indygreg' || github.event_name != 'schedule' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Install System Dependencies
@@ -45,6 +46,7 @@ jobs:
           path: target/release/pythonbuild
 
   image:
+    if: ${{ github.repository_owner == 'indygreg' || github.event_name != 'schedule' }}
     strategy:
       fail-fast: false
       matrix:
@@ -115,6 +117,7 @@ jobs:
           path: build/image-*
 
   build:
+    if: ${{ github.repository_owner == 'indygreg' || github.event_name != 'schedule' }}
     strategy:
       fail-fast: false
       matrix:
@@ -871,8 +874,9 @@ jobs:
 
 
   # GitHub enforces a limit of 256 entries per matrix, which we exceeded above
-  # so the CPytho 3.13 jobs are split out
+  # so the CPython 3.13 jobs are split out
   build-313:
+    if: ${{ github.repository_owner == 'indygreg' || github.event_name != 'schedule' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   pythonbuild:
+    if: ${{ github.repository_owner == 'indygreg' || github.event_name != 'schedule' }}
     runs-on: 'windows-2019'
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +41,7 @@ jobs:
           path: target/release/pythonbuild.exe
 
   build:
+    if: ${{ github.repository_owner == 'indygreg' || github.event_name != 'schedule' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Only run the scheduled cron for upstream:

https://dev.to/hugovk/til-how-to-disable-cron-for-github-forks-2d0l

This is a big CI matrix, we don't need to run the cron on forks, but contributors might nevertheless want run the CI before opening a PR (and clogging up the upstream CI queue).

---

Background: when pushing stuff to other repos, I was wondering why it was taking a long time for jobs to get a runner, but only in the afternoon, and for two or three hours.

After checking it's not a GitHub outage, I figured out it must be a cron from another repo I'd forked. But not so easy to find when you have over [1,000 forks](https://github.com/hugovk?tab=repositories&q=&type=fork&language=&sort=)! So I wrote a script to call the `gh` CLI to find which repo currently had a running CI, and surprise, surprise, it was this big 'un! :D

(As it happens, I got to use the same script a few days later to find another running in the morning!)