### PR TITLE
Remove redundant version check

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   pythonbuild:
     runs-on: 'macos-13'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   check:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   pythonbuild:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ on:
         required: false
         type: boolean
 
+env:
+  FORCE_COLOR: 1
+
 permissions:
   contents: write
   packages: write

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   pythonbuild:
     runs-on: 'windows-2022'

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1493,12 +1493,7 @@ fn validate_extension_modules(
         }
     }
 
-    if (is_linux || is_macos)
-        && matches!(
-            python_major_minor,
-            "3.9" | "3.10" | "3.11" | "3.12" | "3.13"
-        )
-    {
+    if (is_linux || is_macos) {
         wanted.extend([
             "_testbuffer",
             "_testimportmultiple",


### PR DESCRIPTION
Follow on from https://github.com/indygreg/python-build-standalone/pull/385.

`matches!(python_major_minor, "3.9" | "3.10" | "3.11" | "3.12" | "3.13")` is essentially everything and tautologous, so let's remove it.
 
Also add colour to CI logs for readability.