### PR TITLE
Use relocatable shebang with space-in-path robustness

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -858,7 +858,8 @@ def fix_shebang(full):
 
         lines.extend([
             b"#!/bin/sh\n",
-            b'"exec" "\$(dirname \$0)/python${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}" "\$0" "\$@"\n',
+            b"'''exec' \"$(dirname -- \"$(realpath -- \"$0\")\")\"/'python${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}' \"$0\" \"$@\"\n",
+            b"' '''\n",
         ])
 
         lines.extend(fh)

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -858,7 +858,7 @@ def fix_shebang(full):
 
         lines.extend([
             b"#!/bin/sh\n",
-            b"'''exec' \"$(dirname -- \\\"$(realpath -- \\\"$0\\\")\\\")\"/'python${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}' \"$0\" \"$@\"\n",
+            b"'''exec' \"\$(dirname -- \"\$(realpath -- \"\$0\")\")/python${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}\" \"\$0\" \"\$@\"\n",
             b"' '''\n",
         ])
 

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -858,7 +858,7 @@ def fix_shebang(full):
 
         lines.extend([
             b"#!/bin/sh\n",
-            b"'''exec' \"$(dirname -- \"$(realpath -- \"$0\")\")\"/'python${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}' \"$0\" \"$@\"\n",
+            b"'''exec' \"$(dirname -- \\\"$(realpath -- \\\"$0\\\")\\\")\"/'python${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}' \"$0\" \"$@\"\n",
             b"' '''\n",
         ])
 


### PR DESCRIPTION
## Summary

The current shebang seems to fail when the path itself contains spaces. For example:

```
❯ "/Users/crmarsh/Library/Application Support/uv/python/cpython-3.13.0-macos-aarch64-none/bin/pydoc3"
/Users/crmarsh/Library/Application Support/uv/python/cpython-3.13.0-macos-aarch64-none/bin/pydoc3: line 2: /Users/crmarsh/Library
Support/uv/python/cpython-3.13.0-macos-aarch64-none/bin/python3.13: No such file or directory
/Users/crmarsh/Library/Application Support/uv/python/cpython-3.13.0-macos-aarch64-none/bin/pydoc3: line 2: exec: /Users/crmarsh/Library
Support/uv/python/cpython-3.13.0-macos-aarch64-none/bin/python3.13: cannot execute: No such file or directory
```

This PR replaces it with the shebang that we use in uv for relocatable environments, which is outlined in the following series of PRs and issues:

- https://github.com/astral-sh/uv/pull/5515/files#r1694358328
- https://github.com/astral-sh/uv/pull/5640
- https://github.com/astral-sh/uv/pull/8079

Closes https://github.com/indygreg/python-build-standalone/issues/394.

Closes https://github.com/astral-sh/uv/issues/9348.