### PR TITLE
Copy the Python 3.13t executable to the canonical name instead of renaming

### DIFF
--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -1533,7 +1533,7 @@ def build_cpython(
         # free-threading is enabled the name is `python3.13t.exe`.
         canonical_python_exe = install_dir / "python.exe"
         if not canonical_python_exe.exists():
-            os.rename(
+            shutil.copy2(
                 install_dir / python_exe,
                 canonical_python_exe,
             )


### PR DESCRIPTION
As the simplest immediate fix for https://github.com/indygreg/python-build-standalone/issues/405

The main downside here is increased artifact size. I think that's okay for now, we can remove the extra binary in the future once we resolve the root cause. It's only 89K.