### PR TITLE
fix(workflow): use correct input variable for release-create step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       # Create a GitHub release.
       - name: Create GitHub Release
         if: ${{ github.event.inputs.dry-run == 'false' }}
-        run: just release-create ${{ github.events.input.tag }}
+        run: just release-create ${{ github.event.inputs.tag }}
 
       # Uploading the relevant artifact to the GitHub release.
       - run: just release-run ${{ secrets.GITHUB_TOKEN }} ${{ github.event.inputs.sha }} ${{ github.event.inputs.tag }}


### PR DESCRIPTION
The release-create step was using an incorrect variable name (`github.events.input.tag`), which resulted in the `just release-create` command being called without the required tag argument. This commit updates the workflow to use the correct variable (`github.event.inputs.tag`), ensuring the tag is properly passed to the command.

- https://github.com/loong64/python-build-standalone/actions/runs/15469452121/job/43549720438