### PR TITLE
Use release build for libzstd on Unix

### DIFF
--- a/cpython-unix/build-zstd.sh
+++ b/cpython-unix/build-zstd.sh
@@ -57,7 +57,7 @@ index 5e6e8bc..6ca72a1 100644
 EOF
 fi
 
-CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" make -j ${NUM_CPUS} libzstd.a
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" make -j ${NUM_CPUS} libzstd.a-release
 make -j ${NUM_CPUS} install-static DESTDIR=${ROOT}/out
 make -j ${NUM_CPUS} install-includes DESTDIR=${ROOT}/out
 make -j ${NUM_CPUS} install-pc DESTDIR=${ROOT}/out


### PR DESCRIPTION
Per https://github.com/facebook/zstd/blob/dev/lib/Makefile#L205-L207, one must build `libzstd.a` with the `-release` suffix get get a release build.

I'm still verifying this fixes the issue but will report back once verified.

Fixes https://github.com/astral-sh/python-build-standalone/issues/761