### PR TITLE
Replace `setup-just` with `setup-crate`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,10 @@ jobs:
           submodules: recursive
           persist-credentials: true # needed for git operations below
 
-      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v2
+      - uses: extractions/setup-crate@4993624604c307fbca528d28a3c8b60fa5ecc859 # v1.4.0
+        with:
+          repo: casey/just
+          version: 1.42.4
 
       # Perform a release in dry-run mode.
       - run: just release-dry-run ${GH_TOKEN} ${GITHUB_EVENT_INPUTS_SHA} ${GITHUB_EVENT_INPUTS_TAG}


### PR DESCRIPTION
The former is just a composite of a latter, but does not pin to a commit so it violates our policy. I do not think `setup-crate` supports pinning a just commit, so I think we will want to just drop the whole action in the future.

See 
- https://github.com/astral-sh/python-build-standalone/issues/760
- https://github.com/extractions/setup-just/issues/20
- https://github.com/extractions/setup-just/issues/23

See failure at https://github.com/astral-sh/python-build-standalone/actions/runs/17052072811/attempts/1
