### PR TITLE
Bump Windows build timeout to 90m

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -110,7 +110,7 @@ jobs:
           STEPS_GET_LABELS_OUTPUTS_LABELS: ${{ steps.get-labels.outputs.labels }}
 
   build:
-    timeout-minutes: 60
+    timeout-minutes: 90
     needs:
       - generate-matrix
       - crate-build


### PR DESCRIPTION
See https://github.com/astral-sh/python-build-standalone/issues/789