### PR TITLE
windows: Sync SQLite build flags from the UNIX build

### DIFF
--- a/cpython-unix/build-sqlite.sh
+++ b/cpython-unix/build-sqlite.sh
@@ -28,6 +28,7 @@ fi
 unset CXX
 
 CC_FOR_BUILD="${HOST_CC}" \
+# Please try to keep these in sync with cpython-windows/build.py
 CFLAGS="${EXTRA_TARGET_CFLAGS} \
     -DSQLITE_ENABLE_DBSTAT_VTAB \
     -DSQLITE_ENABLE_FTS3 \

--- a/src/verify_distribution.py
+++ b/src/verify_distribution.py
@@ -123,15 +123,8 @@ class TestPythonInterpreter(unittest.TestCase):
         self.assertTrue(hasattr(conn, "enable_load_extension"))
         # Backup feature requires modern SQLite, which we always have.
         self.assertTrue(hasattr(conn, "backup"))
-        # Ensure that various extensions are present. These will raise if they are not. Note that
-        # CPython upstream carries configuration flags for the Windows build, so geopoly is missing
-        # on all versions and rtree is missing in 3.9. On non-Windows platforms, we configure
-        # SQLite ourselves. We might want to patch the build to enable these on Windows, see #666.
-        extensions = ["fts3", "fts4", "fts5"]
-        if os.name != "nt":
-            extensions.append("geopoly")
-        if os.name != "nt" or sys.version_info[0:2] > (3, 9):
-            extensions.append("rtree")
+        # Ensure that various extensions are present. These will raise if they are not.
+        extensions = ["fts3", "fts4", "fts5", "geopoly", "rtree"]
         cursor = conn.cursor()
         for extension in extensions:
             with self.subTest(extension=extension):


### PR DESCRIPTION
Notably this adds
* SQLITE_ENABLE_FTS3_PARENTHESIS (syntax change, see #550)
* SQLITE_ENABLE_DBSTAT_VTAB (#309)
* SQLITE_ENABLE_GEOPOLY (historically present on UNIX, maybe see #694)