### PR TITLE
CI: Disable Docker build summaries and artifacts

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -99,6 +99,8 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         env:
           SOURCE_DATE_EPOCH: 0
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           file: build/${{ matrix.name }}.Dockerfile


### PR DESCRIPTION
The interesting work for our build happens outside of the Docker build, so these just make the GitHub Actions summary page noisier.

https://github.com/docker/build-push-action#environment-variables