### PR TITLE
Add patch to revert change to macOS stack size estimation on 3.15 

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -522,6 +522,11 @@ if [ -n "${CPYTHON_OPTIMIZED}" ]; then
     fi
 fi
 
+# Revert problematic C stack limits refactoring on 3.15 (macOS build issue)
+if [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_15}" && "${PYBUILD_PLATFORM}" = macos* ]]; then
+    patch -p1 -i "${ROOT}/patch-revert-stack-limits-3.15.patch"
+fi
+
 if [ -n "${CPYTHON_LTO}" ]; then
     CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --with-lto"
 fi

--- a/cpython-unix/patch-revert-stack-limits-3.15.patch
+++ b/cpython-unix/patch-revert-stack-limits-3.15.patch
@@ -1,0 +1,17 @@
+diff --git a/Python/ceval.c b/Python/ceval.c
+index f48f412fab8..3bf1c098003 100644
+--- a/Python/ceval.c
++++ b/Python/ceval.c
+@@ -448,12 +448,6 @@ hardware_stack_limits(uintptr_t *top, uintptr_t *base)
+     ULONG guarantee = 0;
+     SetThreadStackGuarantee(&guarantee);
+     *base = (uintptr_t)low + guarantee;
+-#elif defined(__APPLE__)
+-    pthread_t this_thread = pthread_self();
+-    void *stack_addr = pthread_get_stackaddr_np(this_thread); // top of the stack
+-    size_t stack_size = pthread_get_stacksize_np(this_thread);
+-    *top = (uintptr_t)stack_addr;
+-    *base = ((uintptr_t)stack_addr) - stack_size;
+ #else
+     /// XXX musl supports HAVE_PTHRED_GETATTR_NP, but the resulting stack size
+     /// (on alpine at least) is much smaller than expected and imposes undue limits


### PR DESCRIPTION
Reverts https://github.com/python/cpython/pull/139232 to resolve https://github.com/python/cpython/issues/140125

Includes #822 which demonstrates the failure.

We probably shouldn't merge this. Opened for testing purposes.