### PR TITLE
Use siphash on architectures that support misaligned accesses

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -673,7 +673,19 @@ if [ -n "${CROSS_COMPILING}" ]; then
     # default on relatively modern compilers.
     CONFIGURE_FLAGS="${CONFIGURE_FLAGS} ac_cv_pthread=yes"
 
-    # TODO: There are probably more of these, see #399.
+    # Also, it cannot detect whether misaligned memory accesses should
+    # be avoided, and conservatively defaults to yes, which makes it
+    # pick the 'fnv' hash instead of 'siphash', which numba does not
+    # like (#683, see also comment in cpython/configure.ac). These
+    # answers are taken from the Linux kernel source's Kconfig files,
+    # search for HAVE_EFFICIENT_UNALIGNED_ACCESS.
+    case "${TARGET_TRIPLE}" in
+        arm64*|aarch64*|armv7*|thumb7*|ppc64*|s390*|x86*)
+            CONFIGURE_FLAGS="${CONFIGURE_FLAGS} ac_cv_aligned_required=no"
+            ;;
+    esac
+
+    # TODO: There are probably more of these, see #599.
 fi
 
 # We patched configure.ac above. Reflect those changes.

--- a/src/verify_distribution.py
+++ b/src/verify_distribution.py
@@ -249,6 +249,12 @@ class TestPythonInterpreter(unittest.TestCase):
         root = tk.Tk()
         Application(master=root)
 
+    def test_hash_algorithm(self):
+        self.assertTrue(
+            sys.hash_info.algorithm.startswith("siphash"),
+            msg=f"{sys.hash_info.algorithm=!r} is not siphash",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Python uses siphash (siphash13 in 3.11+, siphash24 on older versions) as the default internal hashing algorithm, but only on architectures that support misaligned accesses, i.e., reads/writes of integers from a memory address that is not a round multiple of the integer size. On other architectures it uses fnv, which is not supported by Numba and raises a warning. The distinction between architectures is done by a configure-time code execution check, which is not supported on our cross builds, including on our x86_64_vN microarchitecture builds (see #599), so Python defaults to assuming it is not supported.

Hard-code a list of platforms that are known to support misaligned accesses just fine. Credit to
https://blog.vitlabuda.cz/2025/01/22/unaligned-memory-access-on-various-cpu-architectures.html for pointing out that the Linux kernel has this pretty well documented in Kconfig.

Note that loongarch and riscv have optional support for misaligned access, and it's quite possible that the hardware that people actually use have support for them (or that we are targeting a limited hardware profile anyway for some reason that implies support for misaligned access). I've left them out for now but we can add them later.

Fixes #683.