### PR TITLE
Fix musl detection in Python 3.12 and below

### DIFF
--- a/cpython-unix/build-cpython-host.sh
+++ b/cpython-unix/build-cpython-host.sh
@@ -34,6 +34,17 @@ tar -xf Python-${PYTHON_VERSION}.tar.xz
 
 pushd "Python-${PYTHON_VERSION}"
 
+# Clang 13 actually prints something with --print-multiarch, confusing CPython's
+# configure. This is reported as https://bugs.python.org/issue45405. We nerf the
+# check since we know what we're doing.
+if [[ "${CC}" = "clang" || "${CC}" = "musl-clang" ]]; then
+  if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" ]; then
+    patch -p1 -i ${ROOT}/patch-disable-multiarch-13.patch
+  else
+    patch -p1 -i ${ROOT}/patch-disable-multiarch.patch
+  fi
+fi
+
 autoconf
 
 # When cross-compiling, we need to build a host Python that has working zlib

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -423,6 +423,8 @@ def build_cpython_host(
 
         support = {
             "build-cpython-host.sh",
+            "patch-disable-multiarch.patch",
+            "patch-disable-multiarch-13.patch",
         }
         for s in sorted(support):
             build_env.copy_file(SUPPORT / s)

--- a/cpython-unix/patch-disable-multiarch-13.patch
+++ b/cpython-unix/patch-disable-multiarch-13.patch
@@ -1,0 +1,17 @@
+diff -u 13-a/configure.ac 13-b/configure.ac
+--- 13-a/configure.ac	2024-05-08 05:21:00.000000000 -0400
++++ 13-b/configure.ac	2024-05-19 07:42:23.294762624 -0400
+@@ -1090,12 +1090,7 @@
+ dnl architecture. PLATFORM_TRIPLET will be a pair or single value for these
+ dnl platforms.
+ AC_MSG_CHECKING([for multiarch])
+-AS_CASE([$ac_sys_system],
+-  [Darwin*], [MULTIARCH=""],
+-  [iOS], [MULTIARCH=""],
+-  [FreeBSD*], [MULTIARCH=""],
+-  [MULTIARCH=$($CC --print-multiarch 2>/dev/null)]
+-)
++MULTIARCH=
+ AC_SUBST([MULTIARCH])
+ 
+ if test x$PLATFORM_TRIPLET != x && test x$MULTIARCH != x; then

--- a/cpython-unix/patch-disable-multiarch.patch
+++ b/cpython-unix/patch-disable-multiarch.patch
@@ -1,0 +1,17 @@
+diff --git a/configure.ac b/configure.ac
+index cc69015b10..c77e92affc 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -873,11 +873,7 @@ fi
+ rm -f conftest.c conftest.out
+ 
+ AC_MSG_CHECKING([for multiarch])
+-AS_CASE([$ac_sys_system],
+-  [Darwin*], [MULTIARCH=""],
+-  [FreeBSD*], [MULTIARCH=""],
+-  [MULTIARCH=$($CC --print-multiarch 2>/dev/null)]
+-)
++MULTIARCH=
+ AC_SUBST([MULTIARCH])
+ AC_MSG_RESULT([$MULTIARCH])
+ 


### PR DESCRIPTION
CPython 3.10 and below don't even attempt to fix the target triple for musl. CPython 3.11 and 3.12 do, but in our setup it doens't work right because of an autoconf bug. CPython 3.13 rewrites the target triple detection logic and works fine.

Fixes #724.