### PR TITLE
Skip sys.implementation._multiarch tests on Windows

### DIFF
--- a/src/verify_distribution.py
+++ b/src/verify_distribution.py
@@ -264,7 +264,9 @@ class TestPythonInterpreter(unittest.TestCase):
                 else:
                     self.assertNotIn(libc, value)
 
-        assertLibc(sys.implementation._multiarch)
+        if hasattr(sys.implementation, "_multiarch"):
+            assertLibc(sys.implementation._multiarch)
+
         assertLibc(importlib.machinery.EXTENSION_SUFFIXES[0])
 
 


### PR DESCRIPTION
This isn't present on Windows (which surprises me).