### PR TITLE
Make the Unix build truly relocatable

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -843,6 +843,7 @@ fi
 cat > ${ROOT}/hack_sysconfig.py << EOF
 import json
 import os
+import re
 import sys
 import sysconfig
 
@@ -926,6 +927,44 @@ def format_sysconfigdata():
         fh.close()
 
 
+def make_relocatable():
+    """Make the sysconfigdata file relocatable."""
+    with open(SYSCONFIGDATA, "rb") as fh:
+        data = fh.read()
+
+    globals_dict = {}
+    locals_dict = {}
+    exec(data, globals_dict, locals_dict)
+    build_time_vars = locals_dict['build_time_vars']
+
+    # The pattern looks for '/install' at the start of the string (^) or
+    # following a whitespace character (\s).
+    install_prefix_pattern = re.compile(r"(^|\s)/install")
+
+    # The replacement string. We use a backreference \1 to keep the
+    # whitespace if it was present.
+    relocatable_path = r"\1{python_install}"
+
+    # Replace the install prefix with a relocatable path.
+    for key, value in build_time_vars.items():
+        if isinstance(value, str) and install_prefix_pattern.search(value):
+            new_value = install_prefix_pattern.sub(relocatable_path, value)
+            build_time_vars[key] = f'f"{new_value}"'
+
+    # Write the new sysconfigdata file.
+    with open(SYSCONFIGDATA, "wb") as fh:
+        fh.write(b'# system configuration generated and used by the sysconfig module\n')
+        fh.write(b'from pathlib import Path\n')
+        fh.write(b'python_install = str(Path(__file__).resolve().parent.parent.parent)\n')
+        fh.write(b'build_time_vars = {\n')
+        for key, value in sorted(build_time_vars.items()):
+            if isinstance(value, str) and value.startswith('f"'):
+                 fh.write(('    "%s": %s,\n' % (key, value)).encode("utf-8"))
+            else:
+                fh.write(('    "%s": %s,\n' % (key, json.dumps(value))).encode("utf-8"))
+        fh.write(b'}\n')
+
+
 # Format sysconfig to ensure that string replacements take effect.
 format_sysconfigdata()
 
@@ -961,6 +1000,9 @@ replace_in_all("-I%s/deps/include/ncursesw" % tools_path, "")
 replace_in_all("-I%s/deps/include/uuid" % tools_path, "")
 replace_in_all("-I%s/deps/include" % tools_path, "")
 replace_in_all("-L%s/deps/lib" % tools_path, "")
+
+# Make the sysconfigdata relocatable
+make_relocatable()
 
 EOF
 


### PR DESCRIPTION
Currently, the python build on Unix is not really relocatalbe. When installing, uv further patches the `_sysconfigdata_` file in uv/crates/uv-python/src/sysconfig/mod.rs `update_sysconfig` and `patch_sysconfigdata` function. Since `_sysconfigdata_` file is a python file, we can let it dynamically decide the install path here in python-build-standalone, instead of rely on further patch down the line.

I see from uv/crates/uv-python/src/sysconfig/mod.rs, it also "remove any references to `-isysroot` in a whitespace-separated string". If needed I can add that part of logic to here as well.

The aim for this change is that, for python install to be able to be copied into any place after install, it should still work. Doing so here instead of inside uv should make it more avialable.