### PR TITLE
enable building aarch64-linux targets from macOS

### DIFF
--- a/cpython-unix/build-main.py
+++ b/cpython-unix/build-main.py
@@ -79,7 +79,7 @@ def main():
         "--no-docker",
         action="store_true",
         default=True if sys.platform == "darwin" else False,
-        help="Disable building in Docker",
+        help="Disable building in Docker on Linux hosts.",
     )
     parser.add_argument(
         "--serial",
@@ -129,9 +129,26 @@ def main():
 
     musl = "musl" in target_triple
 
+    # Linux targets can be built on a macOS host using Docker.
+    building_linux_from_macos = sys.platform == "darwin" and "linux" in target_triple
+    if building_linux_from_macos:
+        print("Note: Using Docker to build for Linux on macOS")
+        args.no_docker = False
+
     env = dict(os.environ)
 
-    env["PYBUILD_HOST_PLATFORM"] = host_platform
+    # When building Linux targets from macOS using Docker, map to the equivalent
+    # Linux host platform.
+    effective_host_platform = host_platform
+    if building_linux_from_macos:
+        if host_platform == "macos_arm64":
+            effective_host_platform = "linux_aarch64"
+        else:
+            raise Exception(f"Unhandled macOS platform: {host_platform}")
+        print(
+            f"Building Linux target from macOS using Docker ({effective_host_platform} toolchain)"
+        )
+    env["PYBUILD_HOST_PLATFORM"] = effective_host_platform
     env["PYBUILD_TARGET_TRIPLE"] = target_triple
     env["PYBUILD_BUILD_OPTIONS"] = args.options
     env["PYBUILD_PYTHON_SOURCE"] = python_source

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -100,7 +100,8 @@ def add_target_env(env, build_platform, target_triple, build_env, build_options)
     if build_platform.startswith("linux_"):
         machine = platform.machine()
 
-        if machine == "aarch64":
+        # arm64 allows building for Linux on a macOS host using Docker
+        if machine == "aarch64" or machine == "arm64":
             env["BUILD_TRIPLE"] = "aarch64-unknown-linux-gnu"
             env["TARGET_TRIPLE"] = target_triple
         elif machine == "x86_64":

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -115,6 +115,7 @@ aarch64-unknown-linux-gnu:
   host_platforms:
     - linux_x86_64
     - linux_aarch64
+    - macos_arm64
   pythons_supported:
     - '3.10'
     - '3.11'
@@ -919,6 +920,7 @@ aarch64-unknown-linux-musl:
   host_platforms:
     - linux_x86_64
     - linux_aarch64
+    - macos_arm64
   pythons_supported:
     - '3.10'
     - '3.11'

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -46,6 +46,11 @@ As are various other targets::
     $ ./build-linux.py --target riscv64-unknown-linux-gnu
     $ ./build-linux.py --target s390x-unknown-linux-gnu
 
+Additionally, an arm64 macOS host can be used to build Linux aarch64 targets
+using Docker::
+
+    $ ./build-linux.py --target aarch64-unknown-linux-gnu
+
 macOS
 =====
 


### PR DESCRIPTION
Add the ability to build for aarch64-unknown-linux-{musl,gnu} platforms on an arm64 macOS host using Docker.

For example using:
    ./build-linux.py --target-triple aarch64-unknown-linux-musl --python cpython-3.14