### PR TITLE
Remove unused bzip2 symlinks that fail on Python 3.14+

### DIFF
--- a/cpython-unix/build-bzip2.sh
+++ b/cpython-unix/build-bzip2.sh
@@ -25,3 +25,11 @@ make -j ${NUM_CPUS} install \
     CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" \
     LDFLAGS="${EXTRA_TARGET_LDFLAGS}" \
     PREFIX=${ROOT}/out/tools/deps
+
+# bzip2's Makefile creates these symlinks with absolute paths to the build
+# directory, which break after archive extraction. Only libbz2.a and headers
+# are needed for building CPython - remove the shell utility symlinks.
+rm ${ROOT}/out/tools/deps/bin/bzcmp \
+   ${ROOT}/out/tools/deps/bin/bzless \
+   ${ROOT}/out/tools/deps/bin/bzegrep \
+   ${ROOT}/out/tools/deps/bin/bzfgrep


### PR DESCRIPTION
Python 3.14 changed `tarfile.extractall()` default filter from `fully_trusted` to `data`, which rejects absolute symlinks (PEP 706).

bzip2's Makefile creates symlinks (`bzcmp`, `bzless`, `bzegrep`, `bzfgrep`) with absolute paths to the build directory. These are already broken after extraction and aren't needed; only `libbz2.a` and headers are used.

Fixes #953