### PR TITLE
fix: propagate Tcl library path across Tk-created interpreters

### DIFF
--- a/cpython-unix/patch-tkinter-3.10.patch
+++ b/cpython-unix/patch-tkinter-3.10.patch
@@ -1,5 +1,5 @@
 diff --git a/Modules/_tkinter.c b/Modules/_tkinter.c
-index 2a3e65b6c97..04f2ab0ea10 100644
+index 2a3e65b..2572277 100644
 --- a/Modules/_tkinter.c
 +++ b/Modules/_tkinter.c
 @@ -115,6 +115,7 @@ Copyright (C) 1994 Steen Lumholt.
@@ -18,17 +18,20 @@ index 2a3e65b6c97..04f2ab0ea10 100644
          /* Check expected location for an installed Python first */
          tcl_library_path = PyUnicode_FromString("\\tcl\\tcl" TCL_VERSION);
          if (tcl_library_path == NULL) {
-@@ -169,11 +171,31 @@ _get_tcl_lib_path()
+@@ -169,11 +171,34 @@ _get_tcl_lib_path()
              tcl_library_path = NULL;
  #endif
          }
 +#else
 +        /* Check expected location for an installed Python first */
-+        tcl_library_path = PyUnicode_FromString("/lib/tcl" TCL_VERSION);
-+        if (tcl_library_path == NULL) {
++        PyObject *suffix = PyUnicode_FromString("/lib/tcl" TCL_VERSION);
++        if (suffix == NULL) {
++            Py_DECREF(prefix);
 +            return NULL;
 +        }
-+        tcl_library_path = PyUnicode_Concat(prefix, tcl_library_path);
++        tcl_library_path = PyUnicode_Concat(prefix, suffix);
++        Py_DECREF(suffix);
++        Py_DECREF(prefix);
 +        if (tcl_library_path == NULL) {
 +            return NULL;
 +        }
@@ -51,10 +54,27 @@ index 2a3e65b6c97..04f2ab0ea10 100644
  
  /* The threading situation is complicated.  Tcl is not thread-safe, except
     when configured with --enable-threads.
-@@ -822,6 +844,30 @@ Tkapp_New(const char *screenName, const char *className,
+@@ -709,6 +731,9 @@ Tkapp_New(const char *screenName, const char *className,
+ {
+     TkappObject *v;
+     char *argv0;
++#ifndef MS_WINDOWS
++    int tcl_library_env_set = 0;
++#endif
  
-         ret = GetEnvironmentVariableW(L"TCL_LIBRARY", NULL, 0);
-         if (!ret && GetLastError() == ERROR_ENVVAR_NOT_FOUND) {
+     v = PyObject_New(TkappObject, (PyTypeObject *) Tkapp_Type);
+     if (v == NULL)
+@@ -839,9 +864,41 @@ Tkapp_New(const char *screenName, const char *className,
+             }
+         }
+     }
++#else
++    {
++        const char *env_val = getenv("TCL_LIBRARY");
++        if (!env_val || !env_val[0]) {
++            PyObject *str_path;
++            PyObject *utf8_path;
++
 +            str_path = _get_tcl_lib_path();
 +            if (str_path == NULL && PyErr_Occurred()) {
 +                return NULL;
@@ -68,29 +88,35 @@ index 2a3e65b6c97..04f2ab0ea10 100644
 +                           "tcl_library",
 +                           PyBytes_AS_STRING(utf8_path),
 +                           TCL_GLOBAL_ONLY);
++                setenv("TCL_LIBRARY", PyBytes_AS_STRING(utf8_path), 1);
++                tcl_library_env_set = 1;
 +                Py_DECREF(utf8_path);
 +            }
 +        }
 +    }
-+#else
-+    {
-+        const char *env_val = getenv("TCL_LIBRARY");
-+        if (!env_val) {
-+            PyObject *str_path;
-+            PyObject *utf8_path;
-+
-             str_path = _get_tcl_lib_path();
-             if (str_path == NULL && PyErr_Occurred()) {
-                 return NULL;
-@@ -3628,7 +3674,32 @@ PyInit__tkinter(void)
+ #endif
+ 
+-    if (Tcl_AppInit(v->interp) != TCL_OK) {
++    int app_rc = Tcl_AppInit(v->interp);
++#ifndef MS_WINDOWS
++    if (tcl_library_env_set) {
++        unsetenv("TCL_LIBRARY");
++    }
++#endif
++    if (app_rc != TCL_OK) {
+         PyObject *result = Tkinter_Error(v);
+ #ifdef TKINTER_PROTECT_LOADTK
+         if (wantTk) {
+@@ -3628,7 +3685,33 @@ PyInit__tkinter(void)
                  PyMem_Free(wcs_path);
              }
  #else
 +            int set_var = 0;
 +            PyObject *str_path;
 +            char *path;
++            const char *env_val = getenv("TCL_LIBRARY");
 +
-+            if (!getenv("TCL_LIBRARY")) {
++            if (!env_val || !env_val[0]) {
 +                str_path = _get_tcl_lib_path();
 +                if (str_path == NULL && PyErr_Occurred()) {
 +                    Py_DECREF(m);

--- a/cpython-unix/patch-tkinter-3.11.patch
+++ b/cpython-unix/patch-tkinter-3.11.patch
@@ -1,5 +1,5 @@
 diff --git a/Modules/_tkinter.c b/Modules/_tkinter.c
-index 005036d3ff2..0e64706584a 100644
+index 005036d..1dd202d 100644
 --- a/Modules/_tkinter.c
 +++ b/Modules/_tkinter.c
 @@ -28,9 +28,7 @@ Copyright (C) 1994 Steen Lumholt.
@@ -29,17 +29,20 @@ index 005036d3ff2..0e64706584a 100644
          /* Check expected location for an installed Python first */
          tcl_library_path = PyUnicode_FromString("\\tcl\\tcl" TCL_VERSION);
          if (tcl_library_path == NULL) {
-@@ -177,11 +177,31 @@ _get_tcl_lib_path()
+@@ -177,11 +177,34 @@ _get_tcl_lib_path()
              tcl_library_path = NULL;
  #endif
          }
 +#else
 +        /* Check expected location for an installed Python first */
-+        tcl_library_path = PyUnicode_FromString("/lib/tcl" TCL_VERSION);
-+        if (tcl_library_path == NULL) {
++        PyObject *suffix = PyUnicode_FromString("/lib/tcl" TCL_VERSION);
++        if (suffix == NULL) {
++            Py_DECREF(prefix);
 +            return NULL;
 +        }
-+        tcl_library_path = PyUnicode_Concat(prefix, tcl_library_path);
++        tcl_library_path = PyUnicode_Concat(prefix, suffix);
++        Py_DECREF(suffix);
++        Py_DECREF(prefix);
 +        if (tcl_library_path == NULL) {
 +            return NULL;
 +        }
@@ -62,10 +65,27 @@ index 005036d3ff2..0e64706584a 100644
  
  /* The threading situation is complicated.  Tcl is not thread-safe, except
     when configured with --enable-threads.
-@@ -687,6 +707,30 @@ Tkapp_New(const char *screenName, const char *className,
+@@ -574,6 +594,9 @@ Tkapp_New(const char *screenName, const char *className,
+ {
+     TkappObject *v;
+     char *argv0;
++#ifndef MS_WINDOWS
++    int tcl_library_env_set = 0;
++#endif
  
-         ret = GetEnvironmentVariableW(L"TCL_LIBRARY", NULL, 0);
-         if (!ret && GetLastError() == ERROR_ENVVAR_NOT_FOUND) {
+     v = PyObject_New(TkappObject, (PyTypeObject *) Tkapp_Type);
+     if (v == NULL)
+@@ -704,9 +727,41 @@ Tkapp_New(const char *screenName, const char *className,
+             }
+         }
+     }
++#else
++    {
++        const char *env_val = getenv("TCL_LIBRARY");
++        if (!env_val || !env_val[0]) {
++            PyObject *str_path;
++            PyObject *utf8_path;
++
 +            str_path = _get_tcl_lib_path();
 +            if (str_path == NULL && PyErr_Occurred()) {
 +                return NULL;
@@ -79,29 +99,35 @@ index 005036d3ff2..0e64706584a 100644
 +                           "tcl_library",
 +                           PyBytes_AS_STRING(utf8_path),
 +                           TCL_GLOBAL_ONLY);
++                setenv("TCL_LIBRARY", PyBytes_AS_STRING(utf8_path), 1);
++                tcl_library_env_set = 1;
 +                Py_DECREF(utf8_path);
 +            }
 +        }
 +    }
-+#else
-+    {
-+        const char *env_val = getenv("TCL_LIBRARY");
-+        if (!env_val) {
-+            PyObject *str_path;
-+            PyObject *utf8_path;
-+
-             str_path = _get_tcl_lib_path();
-             if (str_path == NULL && PyErr_Occurred()) {
-                 return NULL;
-@@ -3428,7 +3472,32 @@ PyInit__tkinter(void)
+ #endif
+ 
+-    if (Tcl_AppInit(v->interp) != TCL_OK) {
++    int app_rc = Tcl_AppInit(v->interp);
++#ifndef MS_WINDOWS
++    if (tcl_library_env_set) {
++        unsetenv("TCL_LIBRARY");
++    }
++#endif
++    if (app_rc != TCL_OK) {
+         PyObject *result = Tkinter_Error(v);
+ #ifdef TKINTER_PROTECT_LOADTK
+         if (wantTk) {
+@@ -3428,7 +3483,33 @@ PyInit__tkinter(void)
                  PyMem_Free(wcs_path);
              }
  #else
 +            int set_var = 0;
 +            PyObject *str_path;
 +            char *path;
++            const char *env_val = getenv("TCL_LIBRARY");
 +
-+            if (!getenv("TCL_LIBRARY")) {
++            if (!env_val || !env_val[0]) {
 +                str_path = _get_tcl_lib_path();
 +                if (str_path == NULL && PyErr_Occurred()) {
 +                    Py_DECREF(m);

--- a/cpython-unix/patch-tkinter-3.12.patch
+++ b/cpython-unix/patch-tkinter-3.12.patch
@@ -1,5 +1,5 @@
 diff --git a/Modules/_tkinter.c b/Modules/_tkinter.c
-index 6b5fcb8a365..7b196f40166 100644
+index 60f66a5..dcd10a6 100644
 --- a/Modules/_tkinter.c
 +++ b/Modules/_tkinter.c
 @@ -28,9 +28,7 @@ Copyright (C) 1994 Steen Lumholt.
@@ -12,8 +12,8 @@ index 6b5fcb8a365..7b196f40166 100644
 +#include "pycore_fileutils.h"   // _Py_stat()
  
  #include "pycore_long.h"
- 
-@@ -134,6 +132,7 @@ typedef int Tcl_Size;
+ #include "pycore_sysmodule.h"     // _PySys_GetOptionalAttrString()
+@@ -135,6 +133,7 @@ typedef int Tcl_Size;
  #ifdef MS_WINDOWS
  #include <conio.h>
  #define WAIT_FOR_STDIN
@@ -21,7 +21,7 @@ index 6b5fcb8a365..7b196f40166 100644
  
  static PyObject *
  _get_tcl_lib_path(void)
-@@ -151,6 +150,7 @@ _get_tcl_lib_path(void)
+@@ -152,6 +151,7 @@ _get_tcl_lib_path(void)
              return NULL;
          }
  
@@ -29,17 +29,20 @@ index 6b5fcb8a365..7b196f40166 100644
          /* Check expected location for an installed Python first */
          tcl_library_path = PyUnicode_FromString("\\tcl\\tcl" TCL_VERSION);
          if (tcl_library_path == NULL) {
-@@ -188,11 +188,31 @@ _get_tcl_lib_path(void)
+@@ -191,11 +191,34 @@ _get_tcl_lib_path(void)
              tcl_library_path = NULL;
  #endif
          }
 +#else
 +        /* Check expected location for an installed Python first */
-+        tcl_library_path = PyUnicode_FromString("/lib/tcl" TCL_VERSION);
-+        if (tcl_library_path == NULL) {
++        PyObject *suffix = PyUnicode_FromString("/lib/tcl" TCL_VERSION);
++        if (suffix == NULL) {
++            Py_DECREF(prefix);
 +            return NULL;
 +        }
-+        tcl_library_path = PyUnicode_Concat(prefix, tcl_library_path);
++        tcl_library_path = PyUnicode_Concat(prefix, suffix);
++        Py_DECREF(suffix);
++        Py_DECREF(prefix);
 +        if (tcl_library_path == NULL) {
 +            return NULL;
 +        }
@@ -62,10 +65,27 @@ index 6b5fcb8a365..7b196f40166 100644
  
  /* The threading situation is complicated.  Tcl is not thread-safe, except
     when configured with --enable-threads.
-@@ -713,6 +733,30 @@ Tkapp_New(const char *screenName, const char *className,
+@@ -582,6 +602,9 @@ Tkapp_New(const char *screenName, const char *className,
+ {
+     TkappObject *v;
+     char *argv0;
++#ifndef MS_WINDOWS
++    int tcl_library_env_set = 0;
++#endif
  
-         ret = GetEnvironmentVariableW(L"TCL_LIBRARY", NULL, 0);
-         if (!ret && GetLastError() == ERROR_ENVVAR_NOT_FOUND) {
+     v = PyObject_New(TkappObject, (PyTypeObject *) Tkapp_Type);
+     if (v == NULL)
+@@ -733,9 +756,41 @@ Tkapp_New(const char *screenName, const char *className,
+             }
+         }
+     }
++#else
++    {
++        const char *env_val = getenv("TCL_LIBRARY");
++        if (!env_val || !env_val[0]) {
++            PyObject *str_path;
++            PyObject *utf8_path;
++
 +            str_path = _get_tcl_lib_path();
 +            if (str_path == NULL && PyErr_Occurred()) {
 +                return NULL;
@@ -79,29 +99,35 @@ index 6b5fcb8a365..7b196f40166 100644
 +                           "tcl_library",
 +                           PyBytes_AS_STRING(utf8_path),
 +                           TCL_GLOBAL_ONLY);
++                setenv("TCL_LIBRARY", PyBytes_AS_STRING(utf8_path), 1);
++                tcl_library_env_set = 1;
 +                Py_DECREF(utf8_path);
 +            }
 +        }
 +    }
-+#else
-+    {
-+        const char *env_val = getenv("TCL_LIBRARY");
-+        if (!env_val) {
-+            PyObject *str_path;
-+            PyObject *utf8_path;
-+
-             str_path = _get_tcl_lib_path();
-             if (str_path == NULL && PyErr_Occurred()) {
-                 return NULL;
-@@ -3542,7 +3586,32 @@ PyInit__tkinter(void)
+ #endif
+ 
+-    if (Tcl_AppInit(v->interp) != TCL_OK) {
++    int app_rc = Tcl_AppInit(v->interp);
++#ifndef MS_WINDOWS
++    if (tcl_library_env_set) {
++        unsetenv("TCL_LIBRARY");
++    }
++#endif
++    if (app_rc != TCL_OK) {
+         PyObject *result = Tkinter_Error(v);
+         Py_DECREF((PyObject *)v);
+         return (TkappObject *)result;
+@@ -3548,7 +3603,33 @@ PyInit__tkinter(void)
                  PyMem_Free(wcs_path);
              }
  #else
 +            int set_var = 0;
 +            PyObject *str_path;
 +            char *path;
++            const char *env_val = getenv("TCL_LIBRARY");
 +
-+            if (!getenv("TCL_LIBRARY")) {
++            if (!env_val || !env_val[0]) {
 +                str_path = _get_tcl_lib_path();
 +                if (str_path == NULL && PyErr_Occurred()) {
 +                    Py_DECREF(m);

--- a/cpython-unix/patch-tkinter-3.13.patch
+++ b/cpython-unix/patch-tkinter-3.13.patch
@@ -1,5 +1,5 @@
 diff --git a/Modules/_tkinter.c b/Modules/_tkinter.c
-index 45897817a56..5633187730a 100644
+index 38e6afd..2b69877 100644
 --- a/Modules/_tkinter.c
 +++ b/Modules/_tkinter.c
 @@ -26,9 +26,8 @@ Copyright (C) 1994 Steen Lumholt.
@@ -13,8 +13,8 @@ index 45897817a56..5633187730a 100644
 +#include "pycore_fileutils.h"     // _Py_stat()
  
  #include "pycore_long.h"          // _PyLong_IsNegative()
- 
-@@ -132,6 +131,7 @@ typedef int Tcl_Size;
+ #include "pycore_sysmodule.h"     // _PySys_GetOptionalAttrString()
+@@ -133,6 +132,7 @@ typedef int Tcl_Size;
  #ifdef MS_WINDOWS
  #include <conio.h>
  #define WAIT_FOR_STDIN
@@ -22,7 +22,7 @@ index 45897817a56..5633187730a 100644
  
  static PyObject *
  _get_tcl_lib_path(void)
-@@ -148,6 +148,7 @@ _get_tcl_lib_path(void)
+@@ -150,6 +150,7 @@ _get_tcl_lib_path(void)
              return NULL;
          }
  
@@ -30,17 +30,20 @@ index 45897817a56..5633187730a 100644
          /* Check expected location for an installed Python first */
          tcl_library_path = PyUnicode_FromString("\\tcl\\tcl" TCL_VERSION);
          if (tcl_library_path == NULL) {
-@@ -185,11 +186,31 @@ _get_tcl_lib_path(void)
+@@ -189,11 +190,34 @@ _get_tcl_lib_path(void)
              tcl_library_path = NULL;
  #endif
          }
 +#else
 +        /* Check expected location for an installed Python first */
-+        tcl_library_path = PyUnicode_FromString("/lib/tcl" TCL_VERSION);
-+        if (tcl_library_path == NULL) {
++        PyObject *suffix = PyUnicode_FromString("/lib/tcl" TCL_VERSION);
++        if (suffix == NULL) {
++            Py_DECREF(prefix);
 +            return NULL;
 +        }
-+        tcl_library_path = PyUnicode_Concat(prefix, tcl_library_path);
++        tcl_library_path = PyUnicode_Concat(prefix, suffix);
++        Py_DECREF(suffix);
++        Py_DECREF(prefix);
 +        if (tcl_library_path == NULL) {
 +            return NULL;
 +        }
@@ -63,10 +66,27 @@ index 45897817a56..5633187730a 100644
  
  /* The threading situation is complicated.  Tcl is not thread-safe, except
     when configured with --enable-threads.
-@@ -710,6 +731,30 @@ Tkapp_New(const char *screenName, const char *className,
+@@ -579,6 +600,9 @@ Tkapp_New(const char *screenName, const char *className,
+ {
+     TkappObject *v;
+     char *argv0;
++#ifndef MS_WINDOWS
++    int tcl_library_env_set = 0;
++#endif
  
-         ret = GetEnvironmentVariableW(L"TCL_LIBRARY", NULL, 0);
-         if (!ret && GetLastError() == ERROR_ENVVAR_NOT_FOUND) {
+     v = PyObject_New(TkappObject, (PyTypeObject *) Tkapp_Type);
+     if (v == NULL)
+@@ -733,9 +757,41 @@ Tkapp_New(const char *screenName, const char *className,
+             }
+         }
+     }
++#else
++    {
++        const char *env_val = getenv("TCL_LIBRARY");
++        if (!env_val || !env_val[0]) {
++            PyObject *str_path;
++            PyObject *utf8_path;
++
 +            str_path = _get_tcl_lib_path();
 +            if (str_path == NULL && PyErr_Occurred()) {
 +                return NULL;
@@ -80,29 +100,35 @@ index 45897817a56..5633187730a 100644
 +                           "tcl_library",
 +                           PyBytes_AS_STRING(utf8_path),
 +                           TCL_GLOBAL_ONLY);
++                setenv("TCL_LIBRARY", PyBytes_AS_STRING(utf8_path), 1);
++                tcl_library_env_set = 1;
 +                Py_DECREF(utf8_path);
 +            }
 +        }
 +    }
-+#else
-+    {
-+        const char *env_val = getenv("TCL_LIBRARY");
-+        if (!env_val) {
-+            PyObject *str_path;
-+            PyObject *utf8_path;
-+
-             str_path = _get_tcl_lib_path();
-             if (str_path == NULL && PyErr_Occurred()) {
-                 return NULL;
-@@ -3552,7 +3597,32 @@ PyInit__tkinter(void)
+ #endif
+ 
+-    if (Tcl_AppInit(v->interp) != TCL_OK) {
++    int app_rc = Tcl_AppInit(v->interp);
++#ifndef MS_WINDOWS
++    if (tcl_library_env_set) {
++        unsetenv("TCL_LIBRARY");
++    }
++#endif
++    if (app_rc != TCL_OK) {
+         PyObject *result = Tkinter_Error(v);
+         Py_DECREF((PyObject *)v);
+         return (TkappObject *)result;
+@@ -3532,7 +3588,33 @@ PyInit__tkinter(void)
                  PyMem_Free(wcs_path);
              }
  #else
 +            int set_var = 0;
 +            PyObject *str_path;
 +            char *path;
++            const char *env_val = getenv("TCL_LIBRARY");
 +
-+            if (!getenv("TCL_LIBRARY")) {
++            if (!env_val || !env_val[0]) {
 +                str_path = _get_tcl_lib_path();
 +                if (str_path == NULL && PyErr_Occurred()) {
 +                    Py_DECREF(m);

--- a/cpython-unix/patch-tkinter-3.14.patch
+++ b/cpython-unix/patch-tkinter-3.14.patch
@@ -1,16 +1,16 @@
 diff --git a/Modules/_tkinter.c b/Modules/_tkinter.c
-index e153047b778..02f5d12db1a 100644
+index 08fb961..ab9f222 100644
 --- a/Modules/_tkinter.c
 +++ b/Modules/_tkinter.c
-@@ -115,6 +115,7 @@ Copyright (C) 1994 Steen Lumholt.
+@@ -134,6 +134,7 @@ typedef int Tcl_Size;
  #ifdef MS_WINDOWS
  #include <conio.h>
  #define WAIT_FOR_STDIN
 +#endif
  
  static PyObject *
- _get_tcl_lib_path()
-@@ -132,6 +133,7 @@ _get_tcl_lib_path()
+ _get_tcl_lib_path(void)
+@@ -151,6 +152,7 @@ _get_tcl_lib_path(void)
              return NULL;
          }
  
@@ -18,17 +18,20 @@ index e153047b778..02f5d12db1a 100644
          /* Check expected location for an installed Python first */
          tcl_library_path = PyUnicode_FromString("\\tcl\\tcl" TCL_VERSION);
          if (tcl_library_path == NULL) {
-@@ -169,11 +171,31 @@ _get_tcl_lib_path()
+@@ -190,11 +192,34 @@ _get_tcl_lib_path(void)
              tcl_library_path = NULL;
  #endif
          }
 +#else
 +        /* Check expected location for an installed Python first */
-+        tcl_library_path = PyUnicode_FromString("/lib/tcl" TCL_VERSION);
-+        if (tcl_library_path == NULL) {
++        PyObject *suffix = PyUnicode_FromString("/lib/tcl" TCL_VERSION);
++        if (suffix == NULL) {
++            Py_DECREF(prefix);
 +            return NULL;
 +        }
-+        tcl_library_path = PyUnicode_Concat(prefix, tcl_library_path);
++        tcl_library_path = PyUnicode_Concat(prefix, suffix);
++        Py_DECREF(suffix);
++        Py_DECREF(prefix);
 +        if (tcl_library_path == NULL) {
 +            return NULL;
 +        }
@@ -51,10 +54,27 @@ index e153047b778..02f5d12db1a 100644
  
  /* The threading situation is complicated.  Tcl is not thread-safe, except
     when configured with --enable-threads.
-@@ -822,6 +844,30 @@ Tkapp_New(const char *screenName, const char *className,
+@@ -592,6 +614,9 @@ Tkapp_New(const char *screenName, const char *className,
+ {
+     TkappObject *v;
+     char *argv0;
++#ifndef MS_WINDOWS
++    int tcl_library_env_set = 0;
++#endif
  
-         ret = GetEnvironmentVariableW(L"TCL_LIBRARY", NULL, 0);
-         if (!ret && GetLastError() == ERROR_ENVVAR_NOT_FOUND) {
+     v = PyObject_New(TkappObject, (PyTypeObject *) Tkapp_Type);
+     if (v == NULL)
+@@ -747,9 +772,41 @@ Tkapp_New(const char *screenName, const char *className,
+             }
+         }
+     }
++#else
++    {
++        const char *env_val = getenv("TCL_LIBRARY");
++        if (!env_val || !env_val[0]) {
++            PyObject *str_path;
++            PyObject *utf8_path;
++
 +            str_path = _get_tcl_lib_path();
 +            if (str_path == NULL && PyErr_Occurred()) {
 +                return NULL;
@@ -68,29 +88,35 @@ index e153047b778..02f5d12db1a 100644
 +                           "tcl_library",
 +                           PyBytes_AS_STRING(utf8_path),
 +                           TCL_GLOBAL_ONLY);
++                setenv("TCL_LIBRARY", PyBytes_AS_STRING(utf8_path), 1);
++                tcl_library_env_set = 1;
 +                Py_DECREF(utf8_path);
 +            }
 +        }
 +    }
-+#else
-+    {
-+        const char *env_val = getenv("TCL_LIBRARY");
-+        if (!env_val) {
-+            PyObject *str_path;
-+            PyObject *utf8_path;
-+
-             str_path = _get_tcl_lib_path();
-             if (str_path == NULL && PyErr_Occurred()) {
-                 return NULL;
-@@ -3631,7 +3677,32 @@ PyInit__tkinter(void)
+ #endif
+ 
+-    if (Tcl_AppInit(v->interp) != TCL_OK) {
++    int app_rc = Tcl_AppInit(v->interp);
++#ifndef MS_WINDOWS
++    if (tcl_library_env_set) {
++        unsetenv("TCL_LIBRARY");
++    }
++#endif
++    if (app_rc != TCL_OK) {
+         PyObject *result = Tkinter_Error(v);
+         Py_DECREF((PyObject *)v);
+         return (TkappObject *)result;
+@@ -3590,7 +3647,33 @@ PyInit__tkinter(void)
                  PyMem_Free(wcs_path);
              }
  #else
 +            int set_var = 0;
 +            PyObject *str_path;
 +            char *path;
++            const char *env_val = getenv("TCL_LIBRARY");
 +
-+            if (!getenv("TCL_LIBRARY")) {
++            if (!env_val || !env_val[0]) {
 +                str_path = _get_tcl_lib_path();
 +                if (str_path == NULL && PyErr_Occurred()) {
 +                    Py_DECREF(m);


### PR DESCRIPTION
Fixes #939 

## Problem

tkinter fails with "Can't find a usable init.tcl" on macOS when both:
1. `sys.prefix != sys.base_prefix` (e.g., when using venv, uvx, uv run --isolated)
2. stdin is a non-TTY device (pytest capture, CI, piped input)

## Root cause

On macOS Aqua, when stdin is non-TTY, Tk's init path `(Tk_CreateConsoleWindow` -> `TkpInit`) creates a secondary Tcl interpreter. The existing patch sets `tcl_library` on the main interpreter, but this secondary interpreter doesn't inherit it and falls back to compiled-in search paths that don't exist in a relocated/venv context.

## Fix

Temporarily set the `TCL_LIBRARY` environment variable around the `Tcl_AppInit` call in `Tkapp_New`. The env var is visible to all interpreters Tk creates internally during init, then unset immediately after to avoid environment pollution. Also
extends `_get_tcl_lib_path()` to compute the Tcl library path on Unix (previously Windows-only).

Patches updated for Python 3.10–3.14.