### PR TITLE
Fix `Queue.qsize()` on Linux cross-compilation

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -646,6 +646,16 @@ if [ -n "${CROSS_COMPILING}" ]; then
             ;;
     esac
 
+    # When cross-compiling, configure defaults to assuming `sem_getvalue` is broken,
+    # which causes `multiprocessing.Queue.qsize()` to raise `NotImplementedError`.
+    # Linux has a working `sem_getvalue`, so we explicitly tell configure it's not broken.
+    # macOS is excluded because it genuinely has a non-functional `sem_getvalue`.
+    # See: https://github.com/astral-sh/python-build-standalone/issues/977
+    # See also: https://github.com/python/cpython/issues/101094 (macOS `sem_getvalue` issue)
+    if [[ "${PYBUILD_PLATFORM}" != macos* ]]; then
+        CONFIGURE_FLAGS="${CONFIGURE_FLAGS} ac_cv_broken_sem_getvalue=no"
+    fi
+
     # TODO: There are probably more of these, see #599.
 fi
 


### PR DESCRIPTION
Fixes #977.

`multiprocessing.Queue.qsize()` raises `NotImplementedError` on Linux cross-compiled builds because CPython's `configure`
defaults to `ac_cv_broken_sem_getvalue=yes` when cross-compiling. See [configure.ac](https://github.com/python/cpython/blob/main/configure.ac#L6299-L6301).

This affects all Linux cross-compiled builds. Fix by setting `ac_cv_broken_sem_getvalue=no` for Linux targets (macOS excluded as it genuinely has broken `sem_getvalue`).

cc @jjhelmus @zanieb