### PR TITLE
Fix sem_clockwait detection

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -659,7 +659,7 @@ if [ -n "${CROSS_COMPILING}" ]; then
 fi
 
 # Apply weak sem_clockwait patch for runtime detection on old glibc.
-# When cross-compiling against old glibc headers (< 2.30), configure cannot detect
+# When building against glibc headers older than 2.30, configure cannot detect
 # sem_clockwait, causing threading.Event.wait() to use CLOCK_REALTIME instead of
 # CLOCK_MONOTONIC. This makes waits hang when the system clock jumps backward.
 # The patch declares sem_clockwait as a weak symbol and checks at runtime.

--- a/cpython-unix/patch-sem-clockwait-weak-3.10.patch
+++ b/cpython-unix/patch-sem-clockwait-weak-3.10.patch
@@ -4,8 +4,8 @@
  #endif
  #endif
  
-+/* When cross-compiling against old glibc headers (e.g., glibc < 2.30),
-+ * configure cannot detect sem_clockwait. Declare it as a weak symbol so it
++/* When building against glibc headers older than 2.30, configure cannot
++ * detect sem_clockwait. Declare it as a weak symbol so it
 + * resolves to NULL on old glibc and to the real function on glibc 2.30+.
 + * This enables monotonic clock waits at runtime when available, preventing
 + * hangs when the system clock jumps backward (e.g., NTP sync). */

--- a/cpython-unix/patch-sem-clockwait-weak-3.11.patch
+++ b/cpython-unix/patch-sem-clockwait-weak-3.11.patch
@@ -4,8 +4,8 @@
  #endif
  #endif
  
-+/* When cross-compiling against old glibc headers (e.g., glibc < 2.30),
-+ * configure cannot detect sem_clockwait. Declare it as a weak symbol so it
++/* When building against glibc headers older than 2.30, configure cannot
++ * detect sem_clockwait. Declare it as a weak symbol so it
 + * resolves to NULL on old glibc and to the real function on glibc 2.30+.
 + * This enables monotonic clock waits at runtime when available, preventing
 + * hangs when the system clock jumps backward (e.g., NTP sync). */

--- a/cpython-unix/patch-sem-clockwait-weak-3.12.patch
+++ b/cpython-unix/patch-sem-clockwait-weak-3.12.patch
@@ -4,8 +4,8 @@
  #undef HAVE_SEM_CLOCKWAIT
  #endif
  
-+/* When cross-compiling against old glibc headers (e.g., glibc < 2.30),
-+ * configure cannot detect sem_clockwait. Declare it as a weak symbol so it
++/* When building against glibc headers older than 2.30, configure cannot
++ * detect sem_clockwait. Declare it as a weak symbol so it
 + * resolves to NULL on old glibc and to the real function on glibc 2.30+.
 + * This enables monotonic clock waits at runtime when available, preventing
 + * hangs when the system clock jumps backward (e.g., NTP sync). */

--- a/cpython-unix/patch-sem-clockwait-weak-3.13.patch
+++ b/cpython-unix/patch-sem-clockwait-weak-3.13.patch
@@ -4,8 +4,8 @@
  #undef HAVE_SEM_CLOCKWAIT
  #endif
  
-+/* When cross-compiling against old glibc headers (e.g., glibc < 2.30),
-+ * configure cannot detect sem_clockwait. Declare it as a weak symbol so it
++/* When building against glibc headers older than 2.30, configure cannot
++ * detect sem_clockwait. Declare it as a weak symbol so it
 + * resolves to NULL on old glibc and to the real function on glibc 2.30+.
 + * This enables monotonic clock waits at runtime when available, preventing
 + * hangs when the system clock jumps backward (e.g., NTP sync). */

--- a/cpython-unix/patch-sem-clockwait-weak-3.15.patch
+++ b/cpython-unix/patch-sem-clockwait-weak-3.15.patch
@@ -4,8 +4,8 @@
  
  #include <stdbool.h>
  
-+/* When cross-compiling against old glibc headers (e.g., glibc < 2.30),
-+ * configure cannot detect sem_clockwait. Declare it as a weak symbol so it
++/* When building against glibc headers older than 2.30, configure cannot
++ * detect sem_clockwait. Declare it as a weak symbol so it
 + * resolves to NULL on old glibc and to the real function on glibc 2.30+.
 + * This enables monotonic clock waits at runtime when available, preventing
 + * hangs when the system clock jumps backward (e.g., NTP sync). */


### PR DESCRIPTION
When building against glibc headers older than 2.30 (e.g., Debian Stretch's `glibc 2.24`), configure cannot detect `sem_clockwait` (added in glibc 2.30). This causes CPython to fall back to `sem_timedwait` with CLOCK_REALTIME, making `threading.Event.wait()` hang indefinitely when the system clock jumps backward (e.g., NTP sync).

This PR adds patches that declare `sem_clockwait` as a weak symbol on Linux when configure doesn't detect it. At runtime, the weak symbol resolves to the real function on `glibc 2.30+` or to NULL on older glibc. The patched code checks this at runtime and falls back to `sem_timedwait` gracefully.

Version-specific patches for CPython 3.10, 3.11, 3.12, 3.13+ (including 3.14) and 3.15 (currently in alpha) account for differences in the threading internals across versions.

The issue was first discovered in https://github.com/commaai/openpilot/issues/33993#issuecomment-2605220622

## Test results

All patches verified by building on Debian Stretch (glibc 2.24, where `sem_clockwait` doesn't exist in headers) and running on Debian Bookworm (glibc 2.36):

| Python | Build glibc | Runtime glibc | Weak symbol resolves | `Event.wait(0.1)` |
|--------|------------|--------------|---------------------|-------------------|
| 3.10.19 | 2.24 (Stretch) | 2.36 (Bookworm) | real function | 0.101s |
| 3.11.14 | 2.24 (Stretch) | 2.36 (Bookworm) | real function | 0.103s |
| 3.12.12 | 2.24 (Stretch) | 2.36 (Bookworm) | real function | 0.103s |
| 3.13.12 | 2.24 (Stretch) | 2.36 (Bookworm) | real function | 0.102s |
| 3.14.3 | 2.24 (Stretch) | 2.36 (Bookworm) | real function | 0.102s |
| 3.15.0a6 | 2.24 (Stretch) | 2.36 (Bookworm) | real function | 0.101s |
| 3.12.12 | 2.24 (Stretch) | 2.24 (Stretch) | NULL → `sem_timedwait` fallback | 0.101s |

[test-sem-clockwait.py](https://github.com/user-attachments/files/25472904/test-sem-clockwait.py)