### PR TITLE
Fix backticks and unquoted vars in all the bash scripts

### DIFF
--- a/cpython-unix/build-autoconf.sh
+++ b/cpython-unix/build-autoconf.sh
@@ -5,17 +5,17 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf autoconf-${AUTOCONF_VERSION}.tar.gz
+tar -xf "autoconf-${AUTOCONF_VERSION}.tar.gz"
 
-pushd autoconf-${AUTOCONF_VERSION}
+pushd "autoconf-${AUTOCONF_VERSION}"
 
 CC="${HOST_CC}" CXX="${HOST_CXX}" CFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" LDFLAGS="${EXTRA_HOST_LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
     --prefix=/tools/host
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-bdb.sh
+++ b/cpython-unix/build-bdb.sh
@@ -5,13 +5,13 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf db-${BDB_VERSION}.tar.gz
+tar -xf "db-${BDB_VERSION}.tar.gz"
 
-pushd db-${BDB_VERSION}/build_unix
+pushd "db-${BDB_VERSION}/build_unix"
 
 CONFIGURE_FLAGS="--enable-dbm --disable-shared"
 
@@ -29,10 +29,10 @@ if [ "${CC}" = "clang" ]; then
 fi
 
 CFLAGS="${CFLAGS}" CPPFLAGS="${CFLAGS}" ../dist/configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \
     ${CONFIGURE_FLAGS}
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-binutils.sh
+++ b/cpython-unix/build-binutils.sh
@@ -7,7 +7,7 @@ set -ex
 
 cd /build
 
-tar -xf binutils-${BINUTILS_VERSION}.tar.xz
+tar -xf "binutils-${BINUTILS_VERSION}.tar.xz"
 mkdir binutils-objdir
 pushd binutils-objdir
 
@@ -18,7 +18,7 @@ else
 fi
 
 # gprofng requires a bison newer than what we have. So just disable it.
-../binutils-${BINUTILS_VERSION}/configure \
+"../binutils-${BINUTILS_VERSION}/configure" \
     --build=${triple} \
     --prefix=/tools/host \
     --enable-plugins \
@@ -26,7 +26,7 @@ fi
     --disable-nls \
     --with-sysroot=/
 
-make -j `nproc`
-make install -j `nproc` DESTDIR=/build/out
+make -j "$(nproc)"
+make install -j "$(nproc)" DESTDIR=/build/out
 
 popd

--- a/cpython-unix/build-bzip2.sh
+++ b/cpython-unix/build-bzip2.sh
@@ -5,31 +5,31 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-if [ -e ${TOOLS_PATH}/host/bin/${TOOLCHAIN_PREFIX}ar ]; then
+if [ -e "${TOOLS_PATH}/host/bin/${TOOLCHAIN_PREFIX}ar" ]; then
     AR=${TOOLS_PATH}/host/bin/${TOOLCHAIN_PREFIX}ar
 else
     AR=ar
 fi
 
-tar -xf bzip2-${BZIP2_VERSION}.tar.gz
+tar -xf "bzip2-${BZIP2_VERSION}.tar.gz"
 
-pushd bzip2-${BZIP2_VERSION}
+pushd "bzip2-${BZIP2_VERSION}"
 
-make -j ${NUM_CPUS} install \
-    AR=${AR} \
+make -j "${NUM_CPUS}" install \
+    AR="${AR}" \
     CC="${CC}" \
     CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" \
     LDFLAGS="${EXTRA_TARGET_LDFLAGS}" \
-    PREFIX=${ROOT}/out/tools/deps
+    PREFIX="${ROOT}/out/tools/deps"
 
 # bzip2's Makefile creates these symlinks with absolute paths to the build
 # directory, which break after archive extraction. Only libbz2.a and headers
 # are needed for building CPython - remove the shell utility symlinks.
-rm ${ROOT}/out/tools/deps/bin/bzcmp \
-   ${ROOT}/out/tools/deps/bin/bzless \
-   ${ROOT}/out/tools/deps/bin/bzegrep \
-   ${ROOT}/out/tools/deps/bin/bzfgrep
+rm "${ROOT}/out/tools/deps/bin/bzcmp" \
+   "${ROOT}/out/tools/deps/bin/bzless" \
+   "${ROOT}/out/tools/deps/bin/bzegrep" \
+   "${ROOT}/out/tools/deps/bin/bzfgrep"

--- a/cpython-unix/build-cpython-host.sh
+++ b/cpython-unix/build-cpython-host.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-export ROOT=`pwd`
+export ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:${TOOLS_PATH}/deps/bin:$PATH
 
@@ -28,9 +28,9 @@ else
   sed_args="-i"
 fi
 
-sed ${sed_args} "s|/tools/host|${TOOLS_PATH}/host|g" ${TOOLS_PATH}/host/share/autoconf/autom4te.cfg
+sed ${sed_args} "s|/tools/host|${TOOLS_PATH}/host|g" "${TOOLS_PATH}/host/share/autoconf/autom4te.cfg"
 
-tar -xf Python-${PYTHON_VERSION}.tar.xz
+tar -xf "Python-${PYTHON_VERSION}.tar.xz"
 
 pushd "Python-${PYTHON_VERSION}"
 
@@ -82,7 +82,7 @@ CC="${HOST_CC}" CXX="${HOST_CXX}" CFLAGS="${EXTRA_HOST_CFLAGS}" CPPFLAGS="${EXTR
 # condition in CPython's build system related to directory creation that gets
 # tickled when we do this. https://github.com/python/cpython/issues/109796.
 make -j "${NUM_CPUS}"
-make -j sharedinstall DESTDIR=${ROOT}/out
-make -j install DESTDIR=${ROOT}/out
+make -j sharedinstall DESTDIR="${ROOT}/out"
+make -j install DESTDIR="${ROOT}/out"
 
 popd

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-export ROOT=`pwd`
+export ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:${TOOLS_PATH}/deps/bin:$PATH
 
@@ -39,33 +39,33 @@ else
     sed_args=(-i)
 fi
 
-sed "${sed_args[@]}" "s|/tools/host|${TOOLS_PATH}/host|g" ${TOOLS_PATH}/host/share/autoconf/autom4te.cfg
+sed "${sed_args[@]}" "s|/tools/host|${TOOLS_PATH}/host|g" "${TOOLS_PATH}/host/share/autoconf/autom4te.cfg"
 
 # We force linking of external static libraries by removing the shared
 # libraries. This is hacky. But we're building in a temporary container
 # and it gets the job done.
-find ${TOOLS_PATH}/deps -name '*.so*' -a \! \( -name 'libtcl*.so*' -or -name 'libtk*.so*' \) -exec rm {} \;
+find "${TOOLS_PATH}/deps" -name '*.so*' -a \! \( -name 'libtcl*.so*' -or -name 'libtk*.so*' \) -exec rm {} \;
 
-tar -xf Python-${PYTHON_VERSION}.tar.xz
+tar -xf "Python-${PYTHON_VERSION}.tar.xz"
 
 PIP_WHEEL="${ROOT}/pip-${PIP_VERSION}-py3-none-any.whl"
 SETUPTOOLS_WHEEL="${ROOT}/setuptools-${SETUPTOOLS_VERSION}-py3-none-any.whl"
 
 cat Setup.local
-mv Setup.local Python-${PYTHON_VERSION}/Modules/Setup.local
+mv Setup.local "Python-${PYTHON_VERSION}/Modules/Setup.local"
 
 cat Makefile.extra
 
-pushd Python-${PYTHON_VERSION}
+pushd "Python-${PYTHON_VERSION}"
 
 # configure doesn't support cross-compiling on Apple. Teach it.
 if [[ "${PYBUILD_PLATFORM}" = macos* && -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_13}" ]]; then
     if [ "${PYTHON_MAJMIN_VERSION}" = "3.12" ]; then
-        patch -p1 -i ${ROOT}/patch-apple-cross-3.12.patch
+        patch -p1 -i "${ROOT}/patch-apple-cross-3.12.patch"
     elif [ "${PYTHON_MAJMIN_VERSION}" = "3.13" ]; then
-        patch -p1 -i ${ROOT}/patch-apple-cross-3.13.patch
+        patch -p1 -i "${ROOT}/patch-apple-cross-3.13.patch"
     else
-        patch -p1 -i ${ROOT}/patch-apple-cross.patch
+        patch -p1 -i "${ROOT}/patch-apple-cross.patch"
     fi
 fi
 
@@ -73,7 +73,7 @@ fi
 if [ "${PYBUILD_PLATFORM}" != "macos" ]; then
     case "${PYTHON_MAJMIN_VERSION}" in
         3.10|3.11)
-            patch -p1 -i ${ROOT}/patch-configure-add-loongarch-triplet.patch
+            patch -p1 -i "${ROOT}/patch-configure-add-loongarch-triplet.patch"
             ;;
     esac
 fi
@@ -81,14 +81,14 @@ fi
 # disable readelf check when cross-compiling on older Python versions
 if [ -n "${CROSS_COMPILING}" ]; then
     if [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_11}" ]; then
-        patch -p1 -i ${ROOT}/patch-cross-readelf.patch
+        patch -p1 -i "${ROOT}/patch-cross-readelf.patch"
     fi
 fi
 
 # LIBTOOL_CRUFT is unused and breaks cross-compiling on macOS. Nuke it.
 # Submitted upstream at https://github.com/python/cpython/pull/101048.
 if [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_11}" ]; then
-    patch -p1 -i ${ROOT}/patch-configure-remove-libtool-cruft.patch
+    patch -p1 -i "${ROOT}/patch-configure-remove-libtool-cruft.patch"
 fi
 
 # Configure nerfs RUNSHARED when cross-compiling, which prevents PGO from running when
@@ -99,22 +99,22 @@ fi
 # Merged upstream in Python 3.15, https://github.com/python/cpython/pull/141958
 if [[ -n "${CROSS_COMPILING}" && -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_14}" ]]; then
     if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_14}" ]; then
-        patch -p1 -i ${ROOT}/patch-dont-clear-runshared-14.patch
+        patch -p1 -i "${ROOT}/patch-dont-clear-runshared-14.patch"
     elif [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" ]; then
-        patch -p1 -i ${ROOT}/patch-dont-clear-runshared-13.patch
+        patch -p1 -i "${ROOT}/patch-dont-clear-runshared-13.patch"
     elif [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_11}" ]; then
-        patch -p1 -i ${ROOT}/patch-dont-clear-runshared.patch
+        patch -p1 -i "${ROOT}/patch-dont-clear-runshared.patch"
     else
-        patch -p1 -i ${ROOT}/patch-dont-clear-runshared-legacy.patch
+        patch -p1 -i "${ROOT}/patch-dont-clear-runshared-legacy.patch"
     fi
 fi
 
 # CPython <=3.10 doesn't properly detect musl. CPython <=3.12 tries, but fails
 # in our environment because of an autoconf bug. CPython >=3.13 is fine.
 if [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_10}" ]; then
-    patch -p1 -i ${ROOT}/patch-cpython-configure-target-triple-musl-3.10.patch
+    patch -p1 -i "${ROOT}/patch-cpython-configure-target-triple-musl-3.10.patch"
 elif [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_12}" ]; then
-    patch -p1 -i ${ROOT}/patch-cpython-configure-target-triple-musl-3.12.patch
+    patch -p1 -i "${ROOT}/patch-cpython-configure-target-triple-musl-3.12.patch"
 fi
 
 # Python 3.11 supports using a provided Python to use during bootstrapping
@@ -122,35 +122,35 @@ fi
 # This patch forces always using it. See comment related to
 # `--with-build-python` for more.
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_11}" ]; then
-    patch -p1 -i ${ROOT}/patch-always-build-python-for-freeze.patch
+    patch -p1 -i "${ROOT}/patch-always-build-python-for-freeze.patch"
 fi
 
 # Add a make target to write the PYTHON_FOR_BUILD variable so we can
 # invoke the host Python on our own.
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_12}" ]; then
-    patch -p1 -i ${ROOT}/patch-write-python-for-build-3.12.patch
+    patch -p1 -i "${ROOT}/patch-write-python-for-build-3.12.patch"
 else
-    patch -p1 -i ${ROOT}/patch-write-python-for-build.patch
+    patch -p1 -i "${ROOT}/patch-write-python-for-build.patch"
 fi
 
 # Object files can get listed multiple times leading to duplicate symbols
 # when linking. Prevent this.
 if [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_10}" ]; then
-  patch -p1 -i ${ROOT}/patch-makesetup-deduplicate-objs.patch
+  patch -p1 -i "${ROOT}/patch-makesetup-deduplicate-objs.patch"
 fi
 
 # testembed links against Tcl/Tk and libpython which already includes Tcl/Tk leading duplicate
 # symbols and warnings from objc (which then causes failures in `test_embed` during PGO).
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" ]; then
-  patch -p1 -i ${ROOT}/patch-make-testembed-nolink-tcltk.patch
+  patch -p1 -i "${ROOT}/patch-make-testembed-nolink-tcltk.patch"
 fi
 
 # The default build rule for the macOS dylib doesn't pick up libraries
 # from modules / makesetup. So patch it accordingly.
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" ]; then
-    patch -p1 -i ${ROOT}/patch-macos-link-extension-modules-13.patch
+    patch -p1 -i "${ROOT}/patch-macos-link-extension-modules-13.patch"
 else
-    patch -p1 -i ${ROOT}/patch-macos-link-extension-modules.patch
+    patch -p1 -i "${ROOT}/patch-macos-link-extension-modules.patch"
 fi
 
 # Also on macOS, the `python` executable is linked against libraries defined by statically
@@ -159,9 +159,9 @@ fi
 # library dependencies that shouldn't need to be there.
 if [[ "${PYBUILD_PLATFORM}" = macos* ]]; then
     if [ "${PYTHON_MAJMIN_VERSION}" = "3.10" ]; then
-        patch -p1 -i ${ROOT}/patch-python-link-modules-3.10.patch
+        patch -p1 -i "${ROOT}/patch-python-link-modules-3.10.patch"
     else
-        patch -p1 -i ${ROOT}/patch-python-link-modules-3.11.patch
+        patch -p1 -i "${ROOT}/patch-python-link-modules-3.11.patch"
     fi
 fi
 
@@ -170,30 +170,30 @@ fi
 # appropriate for certain cross-compiling scenarios. See discussion at
 # https://bugs.python.org/issue44689.
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_11}" ]; then
-    patch -p1 -i ${ROOT}/patch-ctypes-callproc.patch
+    patch -p1 -i "${ROOT}/patch-ctypes-callproc.patch"
 else
-    patch -p1 -i ${ROOT}/patch-ctypes-callproc-legacy.patch
+    patch -p1 -i "${ROOT}/patch-ctypes-callproc-legacy.patch"
 fi
 
 # On Windows, CPython looks for the Tcl/Tk libraries relative to the base prefix,
 # which we want. But on Unix, it doesn't. This patch applies similar behavior on Unix,
 # thereby ensuring that the Tcl/Tk libraries are found in the correct location.
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_14}" ]; then
-    patch -p1 -i ${ROOT}/patch-tkinter-3.14.patch
+    patch -p1 -i "${ROOT}/patch-tkinter-3.14.patch"
 elif [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" ]; then
-    patch -p1 -i ${ROOT}/patch-tkinter-3.13.patch
+    patch -p1 -i "${ROOT}/patch-tkinter-3.13.patch"
 elif [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_12}" ]; then
-    patch -p1 -i ${ROOT}/patch-tkinter-3.12.patch
+    patch -p1 -i "${ROOT}/patch-tkinter-3.12.patch"
 elif [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_11}" ]; then
-    patch -p1 -i ${ROOT}/patch-tkinter-3.11.patch
+    patch -p1 -i "${ROOT}/patch-tkinter-3.11.patch"
 elif [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_10}" ]; then
-    patch -p1 -i ${ROOT}/patch-tkinter-3.10.patch
+    patch -p1 -i "${ROOT}/patch-tkinter-3.10.patch"
 fi
 
 # Code that runs at ctypes module import time does not work with
 # non-dynamic binaries. Patch Python to work around this.
 # See https://bugs.python.org/issue37060.
-patch -p1 -i ${ROOT}/patch-ctypes-static-binary.patch
+patch -p1 -i "${ROOT}/patch-ctypes-static-binary.patch"
 
 # We build against libedit instead of readline in all environments.
 #
@@ -206,19 +206,19 @@ if [ "${PYTHON_MAJMIN_VERSION}" = "3.10" ]; then
     # versions of libedit. We need to backport a 3.11 patch to teach the
     # build system about completions.
     # Backport of 9e9df93ffc6df5141843caf651d33d446676a414 from 3.11.
-    patch -p1 -i ${ROOT}/patch-readline-libedit-completions.patch
+    patch -p1 -i "${ROOT}/patch-readline-libedit-completions.patch"
 
     # 3.11 has a patch related to completer delims that closes a feature
     # gap. Backport it as a quality of life enhancement.
     #
     # Backport of 42dd2613fe4bc61e1f633078560f2d84a0a16c3f from 3.11.
-    patch -p1 -i ${ROOT}/patch-readline-libedit-completer-delims.patch
+    patch -p1 -i "${ROOT}/patch-readline-libedit-completer-delims.patch"
 fi
 
 # iOS doesn't have system(). Teach posixmodule.c about that.
 # Python 3.11 makes this a configure time check, so we don't need the patch there.
 if [[ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_10}" ]]; then
-    patch -p1 -i ${ROOT}/patch-posixmodule-remove-system.patch
+    patch -p1 -i "${ROOT}/patch-posixmodule-remove-system.patch"
 fi
 
 # Python 3.11 has configure support for configuring extension modules. We really,
@@ -234,32 +234,32 @@ if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_11}" ]; then
         # modules that are not unavailable (n/a) based on the platform.
         # Valid STATE variables are needed to create the _missing_stdlib_info.py
         # file during the build in Python 3.15+
-        patch -p1 -i ${ROOT}/patch-configure-disable-stdlib-mod-3.12.patch
+        patch -p1 -i "${ROOT}/patch-configure-disable-stdlib-mod-3.12.patch"
     else
-        patch -p1 -i ${ROOT}/patch-configure-disable-stdlib-mod.patch
+        patch -p1 -i "${ROOT}/patch-configure-disable-stdlib-mod.patch"
     fi
 
     # This hack also prevents the conditional definition of the pwd module in
     # Setup.bootstrap.in from working. So we remove that conditional.
-    patch -p1 -i ${ROOT}/patch-pwd-remove-conditional.patch
+    patch -p1 -i "${ROOT}/patch-pwd-remove-conditional.patch"
 fi
 
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_12}" ]; then
     # Additional BOLT optimizations, being upstreamed in
     # https://github.com/python/cpython/issues/128514
-    patch -p1 -i ${ROOT}/patch-configure-bolt-apply-flags-128514.patch
+    patch -p1 -i "${ROOT}/patch-configure-bolt-apply-flags-128514.patch"
 
     # Disable unsafe identical code folding. Objects/typeobject.c
     # update_one_slot requires that wrap_binaryfunc != wrap_binaryfunc_l,
     # despite the functions being identical.
     # https://github.com/python/cpython/pull/134642
-    patch -p1 -i ${ROOT}/patch-configure-bolt-icf-safe.patch
+    patch -p1 -i "${ROOT}/patch-configure-bolt-icf-safe.patch"
 
     # Tweak --skip-funcs to work with our toolchain.
     if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_15}" ]; then
-        patch -p1 -i ${ROOT}/patch-configure-bolt-skip-funcs-3.15.patch
+        patch -p1 -i "${ROOT}/patch-configure-bolt-skip-funcs-3.15.patch"
     else
-        patch -p1 -i ${ROOT}/patch-configure-bolt-skip-funcs.patch
+        patch -p1 -i "${ROOT}/patch-configure-bolt-skip-funcs.patch"
     fi
 fi
 
@@ -267,7 +267,7 @@ fi
 # to PGO targets getting reevaluated after a build when you use multiple
 # make invocations. e.g. `make install` like we do below. Fix that.
 if [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_11}" ]; then
-    patch -p1 -i ${ROOT}/patch-pgo-make-targets.patch
+    patch -p1 -i "${ROOT}/patch-pgo-make-targets.patch"
 fi
 
 # There's a post-build Python script that verifies modules were
@@ -276,16 +276,16 @@ fi
 # own Setup-derived version completely breaks assumptions in this
 # script. So leave it off for now... at our own peril.
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_15}" ]; then
-    patch -p1 -i ${ROOT}/patch-checksharedmods-disable-3.15.patch
+    patch -p1 -i "${ROOT}/patch-checksharedmods-disable-3.15.patch"
 elif [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_12}" ]; then
-    patch -p1 -i ${ROOT}/patch-checksharedmods-disable.patch
+    patch -p1 -i "${ROOT}/patch-checksharedmods-disable.patch"
 fi
 
 # CPython < 3.11 always linked against libcrypt. We backport part of
 # upstream commit be21706f3760bec8bd11f85ce02ed6792b07f51f to avoid this
 # behavior.
 if [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_10}" ]; then
-    patch -p1 -i ${ROOT}/patch-configure-crypt-no-modify-libs.patch
+    patch -p1 -i "${ROOT}/patch-configure-crypt-no-modify-libs.patch"
 fi
 
 # Backport Tcl/Tk 9.0 support from 3.12 to Python 3.10 and 3.11
@@ -294,13 +294,13 @@ if [ "${PYTHON_MAJMIN_VERSION}" = "3.10" ]; then
     # git cherry-pick 625887e6 27cbeb08 d4680b9e ec139c8f
     # manually change int argc/objc -> Tcl_Size argc/objc in file
     # git diff v3.10.19 Modules/_tkinter.c > patch-tkinter-backport-tcl-9-310.patch
-    patch -p1 -i ${ROOT}/patch-tkinter-backport-tcl-9-310.patch
+    patch -p1 -i "${ROOT}/patch-tkinter-backport-tcl-9-310.patch"
 fi
 if [ "${PYTHON_MAJMIN_VERSION}" = "3.11" ]; then
     # git checkout v3.11.14
     # git cherry-pick 625887e6 27cbeb08 d4680b9e ec139c8f
     # git diff v3.11.14 Modules/_tkinter.c > patch-tkinter-backport-tcl-9-311.patch
-    patch -p1 -i ${ROOT}/patch-tkinter-backport-tcl-9-311.patch
+    patch -p1 -i "${ROOT}/patch-tkinter-backport-tcl-9-311.patch"
 fi
 
 # BOLT instrumented binaries segfault in some test_embed tests for unknown reasons.
@@ -308,27 +308,27 @@ fi
 # abort and BOLT optimization uses the partial test results. On 3.13, the segfault
 # is a fatal error. Fixed in 3.14+, https://github.com/python/cpython/pull/128474
 if [ "${PYTHON_MAJMIN_VERSION}" = 3.12 ] || [ "${PYTHON_MAJMIN_VERSION}" = 3.13 ]; then
-    patch -p1 -i ${ROOT}/patch-test-embed-prevent-segfault.patch
+    patch -p1 -i "${ROOT}/patch-test-embed-prevent-segfault.patch"
 fi
 
 # Cherry-pick an upstream change in Python 3.15 to build _asyncio as
 # static (which we do anyway in our own fashion) and more importantly to
 # take this into account when finding the AsyncioDebug section.
 if [ "${PYTHON_MAJMIN_VERSION}" = 3.14 ]; then
-    patch -p1 -i ${ROOT}/patch-python-3.14-asyncio-static.patch
+    patch -p1 -i "${ROOT}/patch-python-3.14-asyncio-static.patch"
 fi
 
 # Ensure the new build-details.json file reports relocatable paths.
 # There is not yet a flag in ./configure for this, sadly.
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_14}" ]; then
-    patch -p1 -i ${ROOT}/patch-python-relative-build-details.patch
+    patch -p1 -i "${ROOT}/patch-python-relative-build-details.patch"
 fi
 
 # Mark _Py_jit_entry as extern in _testiternalcapi/interpreter.c to avoid a duplicate symbols.
 # The symbol is not actually used in the module, a better solution should be found, see:
 # https://github.com/python/cpython/issues/144712
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_15}" ]; then
-    patch -p1 -i ${ROOT}/patch-testinternalcapi-interpreter-extern.patch
+    patch -p1 -i "${ROOT}/patch-testinternalcapi-interpreter-extern.patch"
 fi
 
 # Most bits look at CFLAGS. But setup.py only looks at CPPFLAGS.
@@ -498,7 +498,7 @@ if [ -n "${CPYTHON_OPTIMIZED}" ]; then
         #
         # Backports https://github.com/python/cpython/pull/134276
         if [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" && -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_13}" ]]; then
-            patch -p1 -i ${ROOT}/patch-jit-cflags-313.patch
+            patch -p1 -i "${ROOT}/patch-jit-cflags-313.patch"
         fi
 
 
@@ -701,9 +701,9 @@ CFLAGS=$CFLAGS CPPFLAGS=$CFLAGS CFLAGS_JIT=$CFLAGS_JIT LDFLAGS=$LDFLAGS \
 # Supplement produced Makefile with our modifications.
 cat ../Makefile.extra >> Makefile
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} sharedinstall DESTDIR=${ROOT}/out/python
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out/python
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" sharedinstall DESTDIR="${ROOT}/out/python"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out/python"
 
 
 if [ -n "${CPYTHON_FREETHREADED}" ]; then
@@ -740,31 +740,31 @@ if [ "${PYBUILD_SHARED}" = "1" ]; then
         # Fix the Python binary to reference libpython via @rpath and add
         # an rpath entry so it can find the library.
         install_name_tool \
-            -change /install/lib/${LIBPYTHON_SHARED_LIBRARY_BASENAME} @rpath/${LIBPYTHON_SHARED_LIBRARY_BASENAME} \
+            -change "/install/lib/${LIBPYTHON_SHARED_LIBRARY_BASENAME}" "@rpath/${LIBPYTHON_SHARED_LIBRARY_BASENAME}" \
             -add_rpath @executable_path/../lib \
-            ${ROOT}/out/python/install/bin/python${PYTHON_MAJMIN_VERSION}
+            "${ROOT}/out/python/install/bin/python${PYTHON_MAJMIN_VERSION}"
 
         # Python's build system doesn't make this file writable.
-        chmod 755 ${ROOT}/out/python/install/lib/${LIBPYTHON_SHARED_LIBRARY_BASENAME}
+        chmod 755 "${ROOT}/out/python/install/lib/${LIBPYTHON_SHARED_LIBRARY_BASENAME}"
         # Set libpython's install name to @rpath so binaries linking against it
         # can locate it via their own rpath entries.
         install_name_tool \
-            -id @rpath/${LIBPYTHON_SHARED_LIBRARY_BASENAME} \
-            ${ROOT}/out/python/install/lib/${LIBPYTHON_SHARED_LIBRARY_BASENAME}
+            -id "@rpath/${LIBPYTHON_SHARED_LIBRARY_BASENAME}" \
+            "${ROOT}/out/python/install/lib/${LIBPYTHON_SHARED_LIBRARY_BASENAME}"
 
         # We also normalize /tools/deps/lib/libz.1.dylib to the system location.
         install_name_tool \
             -change /tools/deps/lib/libz.1.dylib /usr/lib/libz.1.dylib \
-            ${ROOT}/out/python/install/bin/python${PYTHON_MAJMIN_VERSION}
+            "${ROOT}/out/python/install/bin/python${PYTHON_MAJMIN_VERSION}"
         install_name_tool \
             -change /tools/deps/lib/libz.1.dylib /usr/lib/libz.1.dylib \
-            ${ROOT}/out/python/install/lib/${LIBPYTHON_SHARED_LIBRARY_BASENAME}
+            "${ROOT}/out/python/install/lib/${LIBPYTHON_SHARED_LIBRARY_BASENAME}"
 
         if [ -n "${PYTHON_BINARY_SUFFIX}" ]; then
             install_name_tool \
-                -change /install/lib/${LIBPYTHON_SHARED_LIBRARY_BASENAME} @rpath/${LIBPYTHON_SHARED_LIBRARY_BASENAME} \
+                -change "/install/lib/${LIBPYTHON_SHARED_LIBRARY_BASENAME}" "@rpath/${LIBPYTHON_SHARED_LIBRARY_BASENAME}" \
                 -add_rpath @executable_path/../lib \
-                ${ROOT}/out/python/install/bin/python${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}
+                "${ROOT}/out/python/install/bin/python${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}"
         fi
 
         # At the moment, python3 and libpython don't have shared-library
@@ -839,11 +839,11 @@ if [ "${PYBUILD_SHARED}" = "1" ]; then
         # ensures they do not use any unwanted symbols. That might be
         # worth doing at some point.)
         patchelf --force-rpath --set-rpath "\$ORIGIN/../lib" \
-            ${ROOT}/out/python/install/bin/python${PYTHON_MAJMIN_VERSION}
+            "${ROOT}/out/python/install/bin/python${PYTHON_MAJMIN_VERSION}"
 
         if [ -n "${PYTHON_BINARY_SUFFIX}" ]; then
             patchelf --force-rpath --set-rpath "\$ORIGIN/../lib" \
-                ${ROOT}/out/python/install/bin/python${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}
+                "${ROOT}/out/python/install/bin/python${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}"
         fi
 
         # For libpython3.so (the ABI3 library for embedders), we do
@@ -865,13 +865,13 @@ if [ "${PYBUILD_SHARED}" = "1" ]; then
             # libpython3.so isn't present in debug builds.
             if [ -z "${CPYTHON_DEBUG}" ]; then
                 patchelf --set-rpath "\$ORIGIN/../lib" \
-                    ${ROOT}/out/python/install/lib/libpython3.so
+                    "${ROOT}/out/python/install/lib/libpython3.so"
             fi
         else
             # libpython3.so isn't present in debug builds.
             if [ -z "${CPYTHON_DEBUG}" ]; then
-                patchelf --replace-needed ${LIBPYTHON_SHARED_LIBRARY_BASENAME} "\$ORIGIN/../lib/${LIBPYTHON_SHARED_LIBRARY_BASENAME}" \
-                    ${ROOT}/out/python/install/lib/libpython3.so
+                patchelf --replace-needed "${LIBPYTHON_SHARED_LIBRARY_BASENAME}" "\$ORIGIN/../lib/${LIBPYTHON_SHARED_LIBRARY_BASENAME}" \
+                    "${ROOT}/out/python/install/lib/libpython3.so"
             fi
         fi
     fi
@@ -899,7 +899,7 @@ fi
 # The goal here is to make the system configuration as generic as possible so
 # that a) it works on as many machines as possible b) doesn't leak details
 # about the build environment, which is non-portable.
-cat > ${ROOT}/hack_sysconfig.py << EOF
+cat > "${ROOT}/hack_sysconfig.py" << EOF
 import json
 import os
 import sys
@@ -1023,10 +1023,10 @@ replace_in_all("-L%s/deps/lib" % tools_path, "")
 
 EOF
 
-${BUILD_PYTHON} ${ROOT}/hack_sysconfig.py ${ROOT}/out/python
+${BUILD_PYTHON} "${ROOT}/hack_sysconfig.py" "${ROOT}/out/python"
 
 # Emit metadata to be used in PYTHON.json.
-cat > ${ROOT}/generate_metadata.py << EOF
+cat > "${ROOT}/generate_metadata.py" << EOF
 import codecs
 import importlib.machinery
 import importlib.util
@@ -1111,17 +1111,17 @@ with open(sys.argv[1], "w") as fh:
     json.dump(metadata, fh, sort_keys=True, indent=4)
 EOF
 
-${BUILD_PYTHON} ${ROOT}/generate_metadata.py ${ROOT}/metadata.json
-cat ${ROOT}/metadata.json
+${BUILD_PYTHON} "${ROOT}/generate_metadata.py" "${ROOT}/metadata.json"
+cat "${ROOT}/metadata.json"
 
 if [ "${CC}" != "musl-clang" ]; then
-    objdump -T ${LIBPYTHON_SHARED_LIBRARY} | grep GLIBC_ | awk '{print $5}' | awk -F_ '{print $2}' | sort -V | tail -n 1 > ${ROOT}/glibc_version.txt
-    cat ${ROOT}/glibc_version.txt
+    objdump -T "${LIBPYTHON_SHARED_LIBRARY}" | grep GLIBC_ | awk '{print $5}' | awk -F_ '{print $2}' | sort -V | tail -n 1 > "${ROOT}/glibc_version.txt"
+    cat "${ROOT}/glibc_version.txt"
 fi
 
 # Downstream consumers don't require bytecode files. So remove them.
 # Ideally we'd adjust the build system. But meh.
-find ${ROOT}/out/python/install -type d -name __pycache__ -print0 | xargs -0 rm -rf
+find "${ROOT}/out/python/install" -type d -name __pycache__ -print0 | xargs -0 rm -rf
 
 # Ensure lib-dynload exists, or Python complains on startup.
 LIB_DYNLOAD=${ROOT}/out/python/install/lib/python${PYTHON_MAJMIN_VERSION}${PYTHON_LIB_SUFFIX}/lib-dynload
@@ -1184,27 +1184,27 @@ esac
 
 LIBPYTHON=libpython${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}.a
 ln -sf \
-    python${PYTHON_MAJMIN_VERSION}${PYTHON_LIB_SUFFIX}/config-${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}-${PYTHON_ARCH}/${LIBPYTHON} \
-    ${ROOT}/out/python/install/lib/${LIBPYTHON}
+    "python${PYTHON_MAJMIN_VERSION}${PYTHON_LIB_SUFFIX}/config-${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}-${PYTHON_ARCH}/${LIBPYTHON}" \
+    "${ROOT}/out/python/install/lib/${LIBPYTHON}"
 
 if [ -n "${PYTHON_BINARY_SUFFIX}" ]; then
     # Ditto for Python executable.
     ln -sf \
-        python${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX} \
-        ${ROOT}/out/python/install/bin/python${PYTHON_MAJMIN_VERSION}
+        "python${PYTHON_MAJMIN_VERSION}${PYTHON_BINARY_SUFFIX}" \
+        "${ROOT}/out/python/install/bin/python${PYTHON_MAJMIN_VERSION}"
 fi
 
-if [ ! -f ${ROOT}/out/python/install/bin/python3 ]; then
+if [ ! -f "${ROOT}/out/python/install/bin/python3" ]; then
     echo "python3 executable does not exist"
     exit 1
 fi
 
 ln -sf \
-    "$(readlink ${ROOT}/out/python/install/bin/python3)" \
-    ${ROOT}/out/python/install/bin/python
+    "$(readlink "${ROOT}/out/python/install/bin/python3")" \
+    "${ROOT}/out/python/install/bin/python"
 
 # Fixup shebangs in Python scripts to reference the local python interpreter.
-cat > ${ROOT}/fix_shebangs.py << EOF
+cat > "${ROOT}/fix_shebangs.py" << EOF
 import os
 import sys
 
@@ -1260,7 +1260,7 @@ for root, dirs, files in os.walk(ROOT):
         fix_shebang(os.path.join(root, f))
 EOF
 
-${BUILD_PYTHON} ${ROOT}/fix_shebangs.py ${ROOT}/out/python/install
+${BUILD_PYTHON} "${ROOT}/fix_shebangs.py" "${ROOT}/out/python/install"
 
 # Also copy object files so they can be linked in a custom manner by
 # downstream consumers.
@@ -1274,15 +1274,15 @@ for d in ${OBJECT_DIRS}; do
     # Not all directories are in all Python versions. And some directories may
     # exist but not have object files.
     if compgen -G "${d}/*.o" > /dev/null; then
-        mkdir -p ${ROOT}/out/python/build/$d
-        cp -av $d/*.o ${ROOT}/out/python/build/$d/
+        mkdir -p "${ROOT}/out/python/build/$d"
+        cp -av "$d"/*.o "${ROOT}/out/python/build/$d"/
     fi
 done
 
 # The object files need to be linked against library dependencies. So copy
 # library files as well.
-mkdir ${ROOT}/out/python/build/lib
-cp -av ${TOOLS_PATH}/deps/lib/*.a ${ROOT}/out/python/build/lib/
+mkdir "${ROOT}/out/python/build/lib"
+cp -av "${TOOLS_PATH}/deps/lib"/*.a "${ROOT}/out/python/build/lib/"
 
 # On Apple, Python uses __builtin_available() to sniff for feature
 # availability. This symbol is defined by clang_rt, which isn't linked
@@ -1293,32 +1293,32 @@ cp -av ${TOOLS_PATH}/deps/lib/*.a ${ROOT}/out/python/build/lib/
 # We copy the libclang_rt.<platform>.a library from our clang into the
 # distribution so it is available. See documentation in quirks.rst for more.
 if [[ "${PYBUILD_PLATFORM}" = macos* ]]; then
-  cp -av $(dirname $(which clang))/../lib/clang/*/lib/darwin/libclang_rt.osx.a ${ROOT}/out/python/build/lib/
+  cp -av "$(dirname "$(which clang)")/../lib/clang"/*/lib/darwin/libclang_rt.osx.a "${ROOT}/out/python/build/lib/"
 fi
 
 # And prune libraries we never reference.
-rm -f ${ROOT}/out/python/build/lib/{libdb-6.0,libxcb-*,libX11-xcb}.a
+rm -f "${ROOT}/out/python/build/lib"/{libdb-6.0,libxcb-*,libX11-xcb}.a
 
 if [ -d "${TOOLS_PATH}/deps/lib/tcl9" ]; then
     # Copy tcl/tk resources needed by tkinter.
-    mkdir ${ROOT}/out/python/install/lib/tcl
+    mkdir "${ROOT}/out/python/install/lib/tcl"
     # Keep this list in sync with tcl_library_paths.
     for source in ${TOOLS_PATH}/deps/lib/{itcl4.3.5,tcl9,tcl9.0,thread3.0.4,tk9.0}; do
-        cp -av $source ${ROOT}/out/python/install/lib/
+        cp -av "$source" "${ROOT}/out/python/install/lib/"
     done
 
     (
         shopt -s nullglob
         dylibs=(${TOOLS_PATH}/deps/lib/lib*.dylib ${TOOLS_PATH}/deps/lib/lib*.so)
         if [ "${#dylibs[@]}" -gt 0 ]; then
-            cp -av "${dylibs[@]}" ${ROOT}/out/python/install/lib/
+            cp -av "${dylibs[@]}" "${ROOT}/out/python/install/lib/"
         fi
     )
 fi
 
 # Copy the terminfo database if present.
 if [ -d "${TOOLS_PATH}/deps/usr/share/terminfo" ]; then
-  cp -av ${TOOLS_PATH}/deps/usr/share/terminfo ${ROOT}/out/python/install/share/
+  cp -av "${TOOLS_PATH}/deps/usr/share/terminfo" "${ROOT}/out/python/install/share/"
 fi
 
 # config.c defines _PyImport_Inittab and extern references to modules, which
@@ -1327,23 +1327,23 @@ fi
 # frozen.c is something similar for frozen modules.
 # Setup.dist/Setup.local are useful to parse for active modules and library
 # dependencies.
-cp -av Modules/config.c ${ROOT}/out/python/build/Modules/
-cp -av Modules/config.c.in ${ROOT}/out/python/build/Modules/
-cp -av Python/frozen.c ${ROOT}/out/python/build/Python/
-cp -av Modules/Setup* ${ROOT}/out/python/build/Modules/
+cp -av Modules/config.c "${ROOT}/out/python/build/Modules/"
+cp -av Modules/config.c.in "${ROOT}/out/python/build/Modules/"
+cp -av Python/frozen.c "${ROOT}/out/python/build/Python/"
+cp -av Modules/Setup* "${ROOT}/out/python/build/Modules/"
 
 # Copy the test hardness runner for convenience.
 # As of Python 3.13, the test harness runner has been removed so we provide a compatibility script
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" ]; then
-    cp -av ${ROOT}/run_tests-13.py ${ROOT}/out/python/build/run_tests.py
+    cp -av "${ROOT}/run_tests-13.py" "${ROOT}/out/python/build/run_tests.py"
 else
-    cp -av Tools/scripts/run_tests.py ${ROOT}/out/python/build/
+    cp -av Tools/scripts/run_tests.py "${ROOT}/out/python/build/"
 fi
 
 # Don't hard-code the build-time prefix into the pkg-config files. See
 # the description of `pcfiledir` in `man pkg-config`.
-find ${ROOT}/out/python/install/lib/pkgconfig -name \*.pc -type f -exec \
+find "${ROOT}/out/python/install/lib/pkgconfig" -name \*.pc -type f -exec \
     sed "${sed_args[@]}" 's|^prefix=/install|prefix=${pcfiledir}/../..|' {} +
 
-mkdir ${ROOT}/out/python/licenses
-cp ${ROOT}/LICENSE.*.txt ${ROOT}/out/python/licenses/
+mkdir "${ROOT}/out/python/licenses"
+cp "${ROOT}"/LICENSE.*.txt "${ROOT}/out/python/licenses/"

--- a/cpython-unix/build-expat.sh
+++ b/cpython-unix/build-expat.sh
@@ -5,20 +5,20 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf expat-${EXPAT_VERSION}.tar.xz
+tar -xf "expat-${EXPAT_VERSION}.tar.xz"
 
-pushd expat-${EXPAT_VERSION}
+pushd "expat-${EXPAT_VERSION}"
 
 # xmlwf isn't needed by CPython.
 # Disable -fexceptions because we don't need it and it adds a dependency on libgcc_s, which
 # is softly undesirable.
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \
     --disable-shared \
     --without-examples \
@@ -26,5 +26,5 @@ CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./
     --without-xmlwf \
     ax_cv_check_cflags___fexceptions=no
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-libX11.sh
+++ b/cpython-unix/build-libX11.sh
@@ -5,13 +5,13 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig:/tools/deps/lib/pkgconfig
 
-tar -xf libX11-${LIBX11_VERSION}.tar.gz
-pushd libX11-${LIBX11_VERSION}
+tar -xf "libX11-${LIBX11_VERSION}.tar.gz"
+pushd "libX11-${LIBX11_VERSION}"
 
 patch -p1 << 'EOF'
 diff --git a/configure b/configure
@@ -119,11 +119,11 @@ CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC -I/tools/deps/include" \
   CFLAGS_FOR_BUILD="-I/tools/deps/include" \
   CPPFLAGS_FOR_BUILD="-I/tools/deps/include" \
   ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \
     --disable-silent-rules \
     ${EXTRA_FLAGS}
 
-make -j `nproc`
-make -j `nproc` install DESTDIR=${ROOT}/out
+make -j "$(nproc)"
+make -j "$(nproc)" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-libXau.sh
+++ b/cpython-unix/build-libXau.sh
@@ -5,23 +5,23 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig:/tools/deps/lib/pkgconfig
 
-tar -xf libXau-${LIBXAU_VERSION}.tar.gz
-pushd libXau-${LIBXAU_VERSION}
+tar -xf "libXau-${LIBXAU_VERSION}.tar.gz"
+pushd "libXau-${LIBXAU_VERSION}"
 
 if [ "${CC}" = "musl-clang" ]; then
     EXTRA_FLAGS="--disable-shared"
 fi
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \
     ${EXTRA_FLAGS}
 
-make -j `nproc`
-make -j `nproc` install DESTDIR=${ROOT}/out
+make -j "$(nproc)"
+make -j "$(nproc)" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-libedit.sh
+++ b/cpython-unix/build-libedit.sh
@@ -5,13 +5,13 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf libedit-${LIBEDIT_VERSION}.tar.gz
+tar -xf "libedit-${LIBEDIT_VERSION}.tar.gz"
 
-pushd libedit-${LIBEDIT_VERSION}
+pushd "libedit-${LIBEDIT_VERSION}"
 
 # libedit's configure isn't smart enough to look for ncursesw. So we teach it
 # to. Ideally we would edit configure.ac and run autoconf. But Jessie's autoconf
@@ -118,17 +118,17 @@ fi
 
 CFLAGS="${cflags}" CPPFLAGS="${cflags}" LDFLAGS="${ldflags}" \
     ./configure \
-        --build=${BUILD_TRIPLE} \
-        --host=${TARGET_TRIPLE} \
+        --build="${BUILD_TRIPLE}" \
+        --host="${TARGET_TRIPLE}" \
         --prefix=/tools/deps \
         --disable-shared
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out"
 
 # Alias readline/{history.h, readline.h} for readline compatibility.
-if [ -e ${ROOT}/out/tools/deps/include ]; then
-    mkdir ${ROOT}/out/tools/deps/include/readline
-    ln -s ../editline/readline.h ${ROOT}/out/tools/deps/include/readline/readline.h
-    ln -s ../editline/readline.h ${ROOT}/out/tools/deps/include/readline/history.h
+if [ -e "${ROOT}/out/tools/deps/include" ]; then
+    mkdir "${ROOT}/out/tools/deps/include/readline"
+    ln -s ../editline/readline.h "${ROOT}/out/tools/deps/include/readline/readline.h"
+    ln -s ../editline/readline.h "${ROOT}/out/tools/deps/include/readline/history.h"
 fi

--- a/cpython-unix/build-libffi-3.3.sh
+++ b/cpython-unix/build-libffi-3.3.sh
@@ -5,13 +5,13 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf libffi-${LIBFFI_3_3_VERSION}.tar.gz
+tar -xf "libffi-${LIBFFI_3_3_VERSION}.tar.gz"
 
-pushd libffi-${LIBFFI_3_3_VERSION}
+pushd "libffi-${LIBFFI_3_3_VERSION}"
 
 EXTRA_CONFIGURE=
 
@@ -22,11 +22,11 @@ if [ "${APPLE_MIN_DEPLOYMENT_TARGET}" = "10.9" ]; then
 fi
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \
     --disable-shared \
     ${EXTRA_CONFIGURE}
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-libffi.sh
+++ b/cpython-unix/build-libffi.sh
@@ -5,13 +5,13 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf libffi-${LIBFFI_VERSION}.tar.gz
+tar -xf "libffi-${LIBFFI_VERSION}.tar.gz"
 
-pushd libffi-${LIBFFI_VERSION}
+pushd "libffi-${LIBFFI_VERSION}"
 
 # Patches needed to fix compilation on aarch64. Will presumably be in libffi
 # 3.4.7 or 3.5.
@@ -384,11 +384,11 @@ if [ "${APPLE_MIN_DEPLOYMENT_TARGET}" = "10.9" ]; then
 fi
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \
     --disable-shared \
     ${EXTRA_CONFIGURE}
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-libpthread-stubs.sh
+++ b/cpython-unix/build-libpthread-stubs.sh
@@ -5,20 +5,20 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 pkg-config --version
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 
-tar -xf libpthread-stubs-${LIBPTHREAD_STUBS_VERSION}.tar.gz
-pushd libpthread-stubs-${LIBPTHREAD_STUBS_VERSION}
+tar -xf "libpthread-stubs-${LIBPTHREAD_STUBS_VERSION}.tar.gz"
+pushd "libpthread-stubs-${LIBPTHREAD_STUBS_VERSION}"
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps
 
-make -j `nproc`
-make -j `nproc` install DESTDIR=${ROOT}/out
+make -j "$(nproc)"
+make -j "$(nproc)" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-libxcb.sh
+++ b/cpython-unix/build-libxcb.sh
@@ -5,13 +5,13 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig:/tools/deps/lib/pkgconfig
 
-tar -xf libxcb-${LIBXCB_VERSION}.tar.gz
-pushd libxcb-${LIBXCB_VERSION}
+tar -xf "libxcb-${LIBXCB_VERSION}.tar.gz"
+pushd "libxcb-${LIBXCB_VERSION}"
 
 if [[ "${TARGET_TRIPLE}" = loongarch64* ]]; then
     rm -f build-aux/config.guess build-aux/config.sub
@@ -24,10 +24,10 @@ if [ "${CC}" = "musl-clang" ]; then
 fi
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC"  CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \
     ${EXTRA_FLAGS}
 
-make -j `nproc`
-make -j `nproc` install DESTDIR=${ROOT}/out
+make -j "$(nproc)"
+make -j "$(nproc)" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-m4.sh
+++ b/cpython-unix/build-m4.sh
@@ -5,17 +5,17 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf m4-${M4_VERSION}.tar.xz
+tar -xf "m4-${M4_VERSION}.tar.xz"
 
-pushd m4-${M4_VERSION}
+pushd "m4-${M4_VERSION}"
 
 CC="${HOST_CC}" CXX="${HOST_CXX}" CFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" LDFLAGS="${EXTRA_HOST_LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
     --prefix=/tools/host
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-mpdecimal.sh
+++ b/cpython-unix/build-mpdecimal.sh
@@ -5,20 +5,20 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf mpdecimal-${MPDECIMAL_VERSION}.tar.gz
+tar -xf "mpdecimal-${MPDECIMAL_VERSION}.tar.gz"
 
-pushd mpdecimal-${MPDECIMAL_VERSION}
+pushd "mpdecimal-${MPDECIMAL_VERSION}"
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \
     --disable-cxx \
     --disable-shared
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-musl.sh
+++ b/cpython-unix/build-musl.sh
@@ -10,9 +10,9 @@ cd /build
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 export CC=clang
 
-tar -xf musl-${MUSL_VERSION}.tar.gz
+tar -xf "musl-${MUSL_VERSION}.tar.gz"
 
-pushd musl-${MUSL_VERSION}
+pushd "musl-${MUSL_VERSION}"
 
 # Debian as of at least bullseye ships musl 1.2.1. musl 1.2.2
 # added reallocarray(), which gets used by at least OpenSSL.
@@ -102,7 +102,7 @@ CFLAGS="${CFLAGS}" CPPFLAGS="${CPPFLAGS}" ./configure \
     --prefix=/tools/host \
     "${SHARED}"
 
-make -j `nproc`
-make -j `nproc` install DESTDIR=/build/out
+make -j "$(nproc)"
+make -j "$(nproc)" install DESTDIR=/build/out
 
 popd

--- a/cpython-unix/build-ncurses.sh
+++ b/cpython-unix/build-ncurses.sh
@@ -5,11 +5,11 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf ncurses-${NCURSES_VERSION}.tar.gz
+tar -xf "ncurses-${NCURSES_VERSION}.tar.gz"
 
 # When cross-compiling, ncurses uses the host `tic` to build the terminfo
 # database. But our build environment's `tic` is too old to process this
@@ -19,27 +19,27 @@ tar -xf ncurses-${NCURSES_VERSION}.tar.gz
 if [[ -n "${CROSS_COMPILING}" && "${PYBUILD_PLATFORM}" != macos* ]]; then
   echo "building host ncurses to provide modern tic for cross-compile"
 
-  pushd ncurses-${NCURSES_VERSION}
+  pushd ncurses-"${NCURSES_VERSION}"
 
   CC="${HOST_CC}" ./configure \
-    --prefix=${TOOLS_PATH}/host \
+    --prefix="${TOOLS_PATH}/host" \
     --without-cxx \
     --without-tests \
     --without-manpages \
     --enable-widec \
     --disable-db-install \
     --enable-symlinks
-  make -j ${NUM_CPUS}
-  make -j ${NUM_CPUS} install
+  make -j "${NUM_CPUS}"
+  make -j "${NUM_CPUS}" install
 
   popd
 
   # Nuke and re-pave the source directory.
-  rm -rf ncurses-${NCURSES_VERSION}
-  tar -xf ncurses-${NCURSES_VERSION}.tar.gz
+  rm -rf "ncurses-${NCURSES_VERSION}"
+  tar -xf "ncurses-${NCURSES_VERSION}.tar.gz"
 fi
 
-pushd ncurses-${NCURSES_VERSION}
+pushd "ncurses-${NCURSES_VERSION}"
 
 # `make install` will strip installed programs (like tic) by default. This is
 # fine. However, cross-compiles can run into issues where `strip` doesn't
@@ -109,10 +109,10 @@ else
   "
 fi
 
-mkdir -p ${ROOT}/out/usr/lib
+mkdir -p "${ROOT}/out/usr/lib"
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure ${CONFIGURE_FLAGS}
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out"
 
-mv ${ROOT}/out/usr/share/terminfo ${ROOT}/out/tools/deps/usr/share/
+mv "${ROOT}/out/usr/share/terminfo" "${ROOT}/out/tools/deps/usr/share/"

--- a/cpython-unix/build-openssl-1.1.sh
+++ b/cpython-unix/build-openssl-1.1.sh
@@ -5,13 +5,13 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf openssl-${OPENSSL_1_1_VERSION}.tar.gz
+tar -xf "openssl-${OPENSSL_1_1_VERSION}.tar.gz"
 
-pushd openssl-${OPENSSL_1_1_VERSION}
+pushd "openssl-${OPENSSL_1_1_VERSION}"
 
 # Otherwise it gets set to /tools/deps/ssl by default.
 case "${TARGET_TRIPLE}" in
@@ -37,7 +37,7 @@ EXTRA_TARGET_CFLAGS=${EXTRA_TARGET_CFLAGS/\-arch x86_64/}
 
 EXTRA_FLAGS="${EXTRA_FLAGS} ${EXTRA_TARGET_CFLAGS}"
 
-/usr/bin/perl ./Configure --prefix=/tools/deps ${OPENSSL_TARGET} no-shared no-tests ${EXTRA_FLAGS}
+/usr/bin/perl ./Configure --prefix=/tools/deps "${OPENSSL_TARGET}" no-shared no-tests ${EXTRA_FLAGS}
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install_sw install_ssldirs DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install_sw install_ssldirs DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-openssl-3.5.sh
+++ b/cpython-unix/build-openssl-3.5.sh
@@ -5,13 +5,13 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf openssl-${OPENSSL_3_5_VERSION}.tar.gz
+tar -xf "openssl-${OPENSSL_3_5_VERSION}.tar.gz"
 
-pushd openssl-${OPENSSL_3_5_VERSION}
+pushd "openssl-${OPENSSL_3_5_VERSION}"
 
 # Otherwise it gets set to /tools/deps/ssl by default.
 case "${TARGET_TRIPLE}" in
@@ -40,11 +40,11 @@ EXTRA_FLAGS="${EXTRA_FLAGS} ${EXTRA_TARGET_CFLAGS}"
 /usr/bin/perl ./Configure \
   --prefix=/tools/deps \
   --libdir=lib \
-  ${OPENSSL_TARGET} \
+  "${OPENSSL_TARGET}" \
   no-legacy \
   no-shared \
   no-tests \
   ${EXTRA_FLAGS}
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install_sw install_ssldirs DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install_sw install_ssldirs DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-patchelf.sh
+++ b/cpython-unix/build-patchelf.sh
@@ -5,30 +5,30 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 
-tar -xf patchelf-${PATCHELF_VERSION}.tar.bz2
+tar -xf "patchelf-${PATCHELF_VERSION}.tar.bz2"
 
 pushd patchelf-0.13.1.20211127.72b6d44
 
 CC="${HOST_CC}" CXX="${HOST_CXX}" CFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" \
     ./configure \
-        --build=${BUILD_TRIPLE} \
-        --host=${TARGET_TRIPLE} \
+        --build="${BUILD_TRIPLE}" \
+        --host="${TARGET_TRIPLE}" \
         --prefix=/tools/host
 
-make -j `nproc`
-make -j `nproc` install DESTDIR=${ROOT}/out
+make -j "$(nproc)"
+make -j "$(nproc)" install DESTDIR="${ROOT}/out"
 
 # Update DT_NEEDED to use the host toolchain's shared libraries, otherwise
 # the defaults of the OS may be used, which would be too old. We run the
 # patched binary afterwards to verify it works without LD_LIBRARY_PATH
 # modification.
-if [ -d /tools/${TOOLCHAIN}/lib ]; then
-    LD_LIBRARY_PATH=/tools/${TOOLCHAIN}/lib src/patchelf --replace-needed libstdc++.so.6 /tools/${TOOLCHAIN}/lib/libstdc++.so.6 ${ROOT}/out/tools/host/bin/patchelf
-    LD_LIBRARY_PATH=/tools/${TOOLCHAIN}/lib src/patchelf --replace-needed libgcc_s.so.1 /tools/${TOOLCHAIN}/lib/libgcc_s.so.1 ${ROOT}/out/tools/host/bin/patchelf
+if [ -d "/tools/${TOOLCHAIN}/lib" ]; then
+    LD_LIBRARY_PATH=/tools/${TOOLCHAIN}/lib src/patchelf --replace-needed libstdc++.so.6 "/tools/${TOOLCHAIN}/lib/libstdc++.so.6" "${ROOT}/out/tools/host/bin/patchelf"
+    LD_LIBRARY_PATH=/tools/${TOOLCHAIN}/lib src/patchelf --replace-needed libgcc_s.so.1 "/tools/${TOOLCHAIN}/lib/libgcc_s.so.1" "${ROOT}/out/tools/host/bin/patchelf"
 fi
 
-${ROOT}/out/tools/host/bin/patchelf --version
+"${ROOT}/out/tools/host/bin/patchelf" --version

--- a/cpython-unix/build-sqlite.sh
+++ b/cpython-unix/build-sqlite.sh
@@ -5,12 +5,12 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf sqlite-autoconf-${SQLITE_VERSION}.tar.gz
-pushd sqlite-autoconf-${SQLITE_VERSION}
+tar -xf "sqlite-autoconf-${SQLITE_VERSION}.tar.gz"
+pushd "sqlite-autoconf-${SQLITE_VERSION}"
 
 
 CONFIGURE_FLAGS="--build=${BUILD_TRIPLE} --host=${TARGET_TRIPLE}"
@@ -35,7 +35,7 @@ CFLAGS="${EXTRA_TARGET_CFLAGS} \
 CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" \
 LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure ${CONFIGURE_FLAGS}
 
-make -j ${NUM_CPUS} libsqlite3.a
-make install-lib DESTDIR=${ROOT}/out
-make install-headers DESTDIR=${ROOT}/out
-make install-pc DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}" libsqlite3.a
+make install-lib DESTDIR="${ROOT}/out"
+make install-headers DESTDIR="${ROOT}/out"
+make install-pc DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-tcl.sh
+++ b/cpython-unix/build-tcl.sh
@@ -5,19 +5,19 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 # Force linking to static libraries from our dependencies.
 # TODO(geofft): This is copied from build-cpython.sh. Really this should
 # be done at the end of the build of each dependency, rather than before
 # the build of each consumer.
-find ${TOOLS_PATH}/deps -name '*.so*' -exec rm {} \;
+find "${TOOLS_PATH}/deps" -name '*.so*' -exec rm {} \;
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 export PKG_CONFIG_PATH=${TOOLS_PATH}/deps/share/pkgconfig:${TOOLS_PATH}/deps/lib/pkgconfig
 
-tar -xf tcl${TCL_VERSION}-src.tar.gz
-pushd tcl${TCL_VERSION}
+tar -xf "tcl${TCL_VERSION}-src.tar.gz"
+pushd "tcl${TCL_VERSION}"
 
 EXTRA_CONFIGURE=
 
@@ -58,7 +58,7 @@ fi
 # It is a self contained header file, use a copy from the container.
 # https://core.tcl-lang.org/tcl/tktview/3ff2d724d03ba7d6edb8
 if [ "${CC}" = "musl-clang" ]; then
-    cp /usr/include/$(uname -m)-linux-gnu/sys/queue.h /tools/host/include/sys
+    cp "/usr/include/$(uname -m)-linux-gnu/sys/queue.h" /tools/host/include/sys
 fi
 
 # Remove packages we don't care about and can pull in unwanted symbols.
@@ -73,19 +73,19 @@ if [[ "${PYBUILD_PLATFORM}" != macos* ]]; then
 fi
 
 CFLAGS="${CFLAGS}" CPPFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \
     --enable-shared"${STATIC:+=no}" \
     --enable-threads \
     --disable-zipfs \
     ${EXTRA_CONFIGURE}
 
-make -j ${NUM_CPUS} DYLIB_INSTALL_DIR=@rpath
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out DYLIB_INSTALL_DIR=@rpath
-make -j ${NUM_CPUS} install-private-headers DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}" DYLIB_INSTALL_DIR=@rpath
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out" DYLIB_INSTALL_DIR=@rpath
+make -j "${NUM_CPUS}" install-private-headers DESTDIR="${ROOT}/out"
 
 if [ -n "${STATIC}" ]; then
     # For some reason libtcl*.a have weird permissions. Fix that.
-    chmod 644 ${ROOT}/out/tools/deps/lib/libtcl*.a
+    chmod 644 "${ROOT}/out/tools/deps/lib"/libtcl*.a
 fi

--- a/cpython-unix/build-tk.sh
+++ b/cpython-unix/build-tk.sh
@@ -5,18 +5,18 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 # Force linking to static libraries from our dependencies.
 # TODO(geofft): This is copied from build-cpython.sh. Really this should
 # be done at the end of the build of each dependency, rather than before
 # the build of each consumer.
-find ${TOOLS_PATH}/deps -name '*.so*' -exec rm {} \;
+find "${TOOLS_PATH}/deps" -name '*.so*' -exec rm {} \;
 
 export PATH=${TOOLS_PATH}/deps/bin:${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 export PKG_CONFIG_PATH=${TOOLS_PATH}/deps/share/pkgconfig:${TOOLS_PATH}/deps/lib/pkgconfig
 
-tar -xf tk${TK_VERSION}-src.tar.gz
+tar -xf "tk${TK_VERSION}-src.tar.gz"
 
 pushd tk*/unix
 
@@ -34,10 +34,10 @@ else
 fi
 
 CFLAGS="${CFLAGS}" CPPFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \
-    --with-tcl=${TOOLS_PATH}/deps/lib \
+    --with-tcl="${TOOLS_PATH}/deps/lib" \
     --enable-shared"${STATIC:+=no}" \
     --enable-threads \
     --disable-zipfs \
@@ -63,14 +63,14 @@ if [[ "${PYBUILD_PLATFORM}" != macos* ]]; then
     MAKE_VARS+=(X11_LIB_SWITCHES="-lX11 -lxcb -lXau")
 fi
 
-make -j ${NUM_CPUS} "${MAKE_VARS[@]}"
+make -j "${NUM_CPUS}" "${MAKE_VARS[@]}"
 touch wish
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out "${MAKE_VARS[@]}"
-make -j ${NUM_CPUS} install-private-headers DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out" "${MAKE_VARS[@]}"
+make -j "${NUM_CPUS}" install-private-headers DESTDIR="${ROOT}/out"
 
 # For some reason libtk*.a have weird permissions. Fix that.
 if [ -n "${STATIC}" ]; then
-    chmod 644 /${ROOT}/out/tools/deps/lib/libtk*.a
+    chmod 644 "/${ROOT}/out/tools/deps/lib"/libtk*.a
 fi
 
-rm ${ROOT}/out/tools/deps/bin/wish*
+rm "${ROOT}/out/tools/deps/bin"/wish*

--- a/cpython-unix/build-uuid.sh
+++ b/cpython-unix/build-uuid.sh
@@ -5,12 +5,12 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf libuuid-${UUID_VERSION}.tar.gz
-pushd libuuid-${UUID_VERSION}
+tar -xf "libuuid-${UUID_VERSION}.tar.gz"
+pushd "libuuid-${UUID_VERSION}"
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC"
 
@@ -18,10 +18,10 @@ CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC"
 CFLAGS="${CFLAGS} -Wno-error=implicit-function-declaration"
 
 CFLAGS="${CFLAGS}" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \
     --disable-shared
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-x11-util-macros.sh
+++ b/cpython-unix/build-x11-util-macros.sh
@@ -5,16 +5,16 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 
-tar -xzf util-macros-${X11_UTIL_MACROS_VERSION}.tar.gz
-pushd util-macros-${X11_UTIL_MACROS_VERSION}
+tar -xzf "util-macros-${X11_UTIL_MACROS_VERSION}.tar.gz"
+pushd "util-macros-${X11_UTIL_MACROS_VERSION}"
 CFLAGS="${EXTRA_TARGET_CFLAGS}" CPPFLAGS="${EXTRA_TARGET_CFLAGS}" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps
 
-make -j `nproc`
-make -j `nproc` install DESTDIR=${ROOT}/out
+make -j "$(nproc)"
+make -j "$(nproc)" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-xcb-proto.sh
+++ b/cpython-unix/build-xcb-proto.sh
@@ -5,20 +5,20 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 pkg-config --version
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 
-tar -xf xcb-proto-${XCB_PROTO_VERSION}.tar.xz
-pushd xcb-proto-${XCB_PROTO_VERSION}
+tar -xf "xcb-proto-${XCB_PROTO_VERSION}.tar.xz"
+pushd "xcb-proto-${XCB_PROTO_VERSION}"
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps
 
-make -j `nproc`
-make -j `nproc` install DESTDIR=${ROOT}/out
+make -j "$(nproc)"
+make -j "$(nproc)" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-xorgproto.sh
+++ b/cpython-unix/build-xorgproto.sh
@@ -5,15 +5,15 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 pkg-config --version
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 
-tar -xf xorgproto-${XORGPROTO_VERSION}.tar.gz
-pushd xorgproto-${XORGPROTO_VERSION}
+tar -xf "xorgproto-${XORGPROTO_VERSION}.tar.gz"
+pushd "xorgproto-${XORGPROTO_VERSION}"
 
 if [[ "${TARGET_TRIPLE}" = loongarch64* ]]; then
     rm -f config.guess.sub config.sub
@@ -22,9 +22,9 @@ if [[ "${TARGET_TRIPLE}" = loongarch64* ]]; then
 fi
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps
 
-make -j `nproc`
-make -j `nproc` install DESTDIR=${ROOT}/out
+make -j "$(nproc)"
+make -j "$(nproc)" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-xtrans.sh
+++ b/cpython-unix/build-xtrans.sh
@@ -5,20 +5,20 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 pkg-config --version
 
 export PATH=/tools/${TOOLCHAIN}/bin:/tools/host/bin:$PATH
 export PKG_CONFIG_PATH=/tools/deps/share/pkgconfig
 
-tar -xf xtrans-${XTRANS_VERSION}.tar.gz
-pushd xtrans-${XTRANS_VERSION}
+tar -xf "xtrans-${XTRANS_VERSION}.tar.gz"
+pushd "xtrans-${XTRANS_VERSION}"
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps
 
-make -j `nproc`
-make -j `nproc` install DESTDIR=${ROOT}/out
+make -j "$(nproc)"
+make -j "$(nproc)" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-xz.sh
+++ b/cpython-unix/build-xz.sh
@@ -5,13 +5,13 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf xz-${XZ_VERSION}.tar.gz
+tar -xf "xz-${XZ_VERSION}.tar.gz"
 
-pushd xz-${XZ_VERSION}
+pushd "xz-${XZ_VERSION}"
 
 EXTRA_CONFIGURE_FLAGS=
 
@@ -23,8 +23,8 @@ if [ "${CC}" = "musl-clang" ]; then
 fi
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CCASFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
-    --build=${BUILD_TRIPLE} \
-    --host=${TARGET_TRIPLE} \
+    --build="${BUILD_TRIPLE}" \
+    --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \
     --disable-shared \
     --disable-xz \
@@ -35,5 +35,5 @@ CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" CC
     --disable-scripts \
     ${EXTRA_CONFIGURE_FLAGS}
 
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-zlib.sh
+++ b/cpython-unix/build-zlib.sh
@@ -5,16 +5,16 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 
-tar -xf zlib-${ZLIB_VERSION}.tar.gz
+tar -xf "zlib-${ZLIB_VERSION}.tar.gz"
 
-pushd zlib-${ZLIB_VERSION}
+pushd "zlib-${ZLIB_VERSION}"
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" ./configure \
   --prefix=/tools/deps \
   --static
-make -j ${NUM_CPUS}
-make -j ${NUM_CPUS} install DESTDIR=${ROOT}/out
+make -j "${NUM_CPUS}"
+make -j "${NUM_CPUS}" install DESTDIR="${ROOT}/out"

--- a/cpython-unix/build-zstd.sh
+++ b/cpython-unix/build-zstd.sh
@@ -5,14 +5,14 @@
 
 set -ex
 
-ROOT=`pwd`
+ROOT=$(pwd)
 
 export PATH=${TOOLS_PATH}/${TOOLCHAIN}/bin:${TOOLS_PATH}/host/bin:$PATH
 export PREFIX="/tools/deps"
 
-tar -xf zstd-${ZSTD_VERSION}.tar.gz
+tar -xf "zstd-${ZSTD_VERSION}.tar.gz"
 
-pushd cpython-source-deps-zstd-${ZSTD_VERSION}/lib
+pushd "cpython-source-deps-zstd-${ZSTD_VERSION}/lib"
 
 if [ "${CC}" = "musl-clang" ]; then
     # In order to build the library with intrinsics, we need musl-clang to find
@@ -25,7 +25,7 @@ if [ "${CC}" = "musl-clang" ]; then
             if [ -e "${TOOLS_PATH}/host/include/${filename}" ]; then
                 echo "warning: ${filename} already exists"
             fi
-            cp "$h" ${TOOLS_PATH}/host/include/
+            cp "$h" "${TOOLS_PATH}/host/include/"
         else
             echo "warning: ${filename} not found (skipping)"
         fi
@@ -79,7 +79,7 @@ index 2ef33c7..078e2ee 100644
 EOF
 fi
 
-CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC -DZSTD_MULTITHREAD -O3" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" make -j ${NUM_CPUS} VERBOSE=1 libzstd.a
-make -j ${NUM_CPUS} install-static DESTDIR=${ROOT}/out
-make -j ${NUM_CPUS} install-includes DESTDIR=${ROOT}/out
-MT=1 make -j ${NUM_CPUS} install-pc DESTDIR=${ROOT}/out
+CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC -DZSTD_MULTITHREAD -O3" LDFLAGS="${EXTRA_TARGET_LDFLAGS}" make -j "${NUM_CPUS}" VERBOSE=1 libzstd.a
+make -j "${NUM_CPUS}" install-static DESTDIR="${ROOT}/out"
+make -j "${NUM_CPUS}" install-includes DESTDIR="${ROOT}/out"
+MT=1 make -j "${NUM_CPUS}" install-pc DESTDIR="${ROOT}/out"


### PR DESCRIPTION
There might be some more candidates but I think the next goal will be to use arrays for all the extra args things to avoid needing to use splitting anywhere, then it should be easy to clean up the rest.