### PR TITLE
use profile2 to split blocks during BOLT

### DIFF
--- a/cpython-unix/patch-configure-bolt-apply-flags-128514.patch
+++ b/cpython-unix/patch-configure-bolt-apply-flags-128514.patch
@@ -8,7 +8,7 @@ index ee034e5a962..f1a69b7d4a7 100644
       -reorder-blocks=ext-tsp
       -reorder-functions=cdsort
       -split-functions
-+     -split-strategy=cdsplit
++     -split-strategy=profile2
       -icf=1
       -inline-all
       -split-eh

--- a/cpython-unix/patch-configure-bolt-icf-safe.patch
+++ b/cpython-unix/patch-configure-bolt-icf-safe.patch
@@ -73,7 +73,7 @@ index 8d939f07505..25737e3f9d6 100644
       -reorder-blocks=ext-tsp
       -reorder-functions=cdsort
       -split-functions
-      -split-strategy=cdsplit
+      -split-strategy=profile2
 -     -icf=1
 +     ${py_bolt_icf_flag}
       -inline-all


### PR DESCRIPTION
Split functions into hot, cold fragments rather than hot, warm and cold.

fixes #991