### PR TITLE
add deprecation warnings to build-{linux,macos}.py

### DIFF
--- a/build-linux.py
+++ b/build-linux.py
@@ -53,7 +53,8 @@ if __name__ == "__main__":
     warnings.warn(
         "build-macos.py is deprecated and will be removed in the future.\n"
         + "Please use ./build.py to build a distribution.",
-        DeprecationWarning,
+        FutureWarning,
+        stacklevel=2,
     )
     try:
         if "PYBUILD_BOOTSTRAPPED" not in os.environ:

--- a/build-macos.py
+++ b/build-macos.py
@@ -53,7 +53,8 @@ if __name__ == "__main__":
     warnings.warn(
         "build-macos.py is deprecated and will be removed in the future.\n"
         + "Please use ./build.py to build a distribution.",
-        DeprecationWarning,
+        FutureWarning,
+        stacklevel=2,
     )
     try:
         if "PYBUILD_BOOTSTRAPPED" not in os.environ:


### PR DESCRIPTION
Add a deprecation warning to the build-linux.py and build.macos.py scripts informing users of the their future removal and directing users to ./build.py.