### PR TITLE
ci: use larger Depot Linux runners

### DIFF
--- a/ci-runners.yaml
+++ b/ci-runners.yaml
@@ -1,11 +1,11 @@
 # Describes the runners that the CI system can use
 
-depot-ubuntu-22.04:
+depot-ubuntu-22.04-4:
   arch: x86_64
   platform: linux
   free: false
 
-depot-ubuntu-22.04-arm:
+depot-ubuntu-22.04-arm-4:
   arch: aarch64
   platform: linux
   free: false


### PR DESCRIPTION
Default runners have 2 CPUs. We can achieve a nice speed-up (but not quite linear) by leveraging runners with more CPUs.