### PR TITLE
unix: build test extensions as shared libraries; enable _testcapi

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -616,6 +616,11 @@ if [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_14}" ]]; then
     PROFILE_TASK="${PROFILE_TASK} --ignore test_json"
 fi
 
+# PGO optimized / BOLT instrumented binaries segfault in a test_bytes test. Skip it.
+if [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" && "${TARGET_TRIPLE}" == x86_64* ]]; then
+    PROFILE_TASK="${PROFILE_TASK} --ignore test.test_bytes.BytesTest.test_from_format"
+fi
+
 # ./configure tries to auto-detect whether it can build 128-bit and 256-bit SIMD helpers for HACL,
 # but on x86-64 that requires v2 and v3 respectively, and on arm64 the performance is bad as noted
 # in the comments, so just don't even try. (We should check if we can make this conditional)
@@ -1315,7 +1320,7 @@ ${BUILD_PYTHON} "${ROOT}/fix_shebangs.py" "${ROOT}/out/python/install"
 # downstream consumers.
 OBJECT_DIRS="Objects Parser Parser/lexer Parser/pegen Parser/tokenizer Programs Python Python/deepfreeze"
 OBJECT_DIRS="${OBJECT_DIRS} Modules"
-for ext in _blake2 cjkcodecs _ctypes _ctypes/darwin _decimal _expat _hacl _io _multiprocessing _remote_debugging _sha3 _sqlite _sre _testinternalcapi _xxtestfuzz _zstd; do
+for ext in _blake2 cjkcodecs _ctypes _ctypes/darwin _decimal _expat _hacl _io _multiprocessing _remote_debugging _sha3 _sqlite _sre _testcapi _testinternalcapi _testlimitedcapi _xxtestfuzz _zstd; do
     OBJECT_DIRS="${OBJECT_DIRS} Modules/${ext}"
 done
 

--- a/cpython-unix/extension-modules.yml
+++ b/cpython-unix/extension-modules.yml
@@ -607,32 +607,133 @@ _sysconfig:
 
 _testbuffer:
   minimum-python-version: '3.10'
+  build-mode: shared
   sources:
     - _testbuffer.c
 
-# _testcapi exists to test the public C APIs. It makes assumptions that it is
-# built as a shared library. Our static extension module builds invalidate this
-# assumption. So just disable globally.
 _testcapi:
-  disabled-targets:
-    - .*
+  # Must link against public API, which isn't available in static build.
+  build-mode: shared-or-disabled
   sources:
     - _testcapimodule.c
+  sources-conditional:
+    - source: _testcapi/abstract.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/buffer.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/bytearray.c
+      minimum-python-version: "3.12"
+      maximum-python-version: "3.12"
+    - source: _testcapi/bytes.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/code.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/codec.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/complex.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/config.c
+      minimum-python-version: "3.14"
+    - source: _testcapi/datetime.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/dict.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/docstring.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/eval.c
+      minimum-python-version: "3.12"
+      maximum-python-version: "3.12"
+    - source: _testcapi/exceptions.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/file.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/float.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/frame.c
+      minimum-python-version: "3.14"
+    - source: _testcapi/function.c
+      minimum-python-version: "3.14"
+    - source: _testcapi/gc.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/getargs.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/hash.c
+      minimum-python-version: "3.13"
+    - source: _testcapi/heaptype.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/heaptype_relative.c
+      maximum-python-version: "3.12"
+      minimum-python-version: "3.12"
+    - source: _testcapi/immortal.c
+      minimum-python-version: "3.12"
+    # import.c was added in 3.12, removed in 3.13, and added again in 3.14.
+    - source: _testcapi/import.c
+      minimum-python-version: "3.12"
+      maximum-python-version: "3.12"
+    - source: _testcapi/import.c
+      minimum-python-version: "3.14"
+    - source: _testcapi/list.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/long.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/mem.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/modsupport.c
+      minimum-python-version: "3.15"
+    - source: _testcapi/module.c
+      minimum-python-version: "3.15"
+    - source: _testcapi/monitoring.c
+      minimum-python-version: "3.13"
+    - source: _testcapi/numbers.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/object.c
+      minimum-python-version: "3.13"
+    - source: _testcapi/pyatomic.c
+      minimum-python-version: "3.13"
+    - source: _testcapi/pyos.c
+      minimum-python-version: "3.12"
+      maximum-python-version: "3.12"
+    - source: _testcapi/pytime.c
+      minimum-python-version: "3.12"
+      maximum-python-version: "3.12"
+    - source: _testcapi/run.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/set.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/structmember.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/sys.c
+      minimum-python-version: "3.12"
+      maximum-python-version: "3.12"
+    - source: _testcapi/time.c
+      minimum-python-version: "3.13"
+    - source: _testcapi/tuple.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/type.c
+      minimum-python-version: "3.14"
+    - source: _testcapi/unicode.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/vectorcall.c
+      minimum-python-version: "3.12"
+    - source: _testcapi/vectorcall_limited.c
+      minimum-python-version: "3.12"
+      maximum-python-version: "3.12"
+    - source: _testcapi/watchers.c
+      minimum-python-version: "3.12"
 
 _testexternalinspection:
   minimum-python-version: '3.13'
   maximum-python-version: '3.13'
+  build-mode: shared
   sources:
     - _testexternalinspection.c
 
 _testimportmultiple:
   minimum-python-version: '3.10'
+  build-mode: shared
   sources:
     - _testimportmultiple.c
 
-# Ideally we disable all test extensions. However, this one is used by a bunch
-# of tests, including tests that run during PGO profiling. We keep it enabled
-# so it doesn't break tests and undermine PGO.
 _testinternalcapi:
   includes:
     - Include/internal
@@ -657,13 +758,48 @@ _testinternalcapi:
     - source: _testinternalcapi/tuple.c
       minimum-python-version: "3.15"
 
+_testlimitedcapi:
+  minimum-python-version: "3.13"
+  # Must link against public API, which isn't available in static build.
+  build-mode: shared-or-disabled
+  sources:
+    - _testlimitedcapi.c
+    - _testlimitedcapi/abstract.c
+    - _testlimitedcapi/bytearray.c
+    - _testlimitedcapi/bytes.c
+    - _testlimitedcapi/complex.c
+    - _testlimitedcapi/dict.c
+    - _testlimitedcapi/eval.c
+    - _testlimitedcapi/file.c
+    - _testlimitedcapi/float.c
+    - _testlimitedcapi/heaptype_relative.c
+    - _testlimitedcapi/import.c
+    - _testlimitedcapi/list.c
+    - _testlimitedcapi/long.c
+    - _testlimitedcapi/object.c
+    - _testlimitedcapi/pyos.c
+    - _testlimitedcapi/set.c
+    - _testlimitedcapi/sys.c
+    - _testlimitedcapi/tuple.c
+    - _testlimitedcapi/unicode.c
+    - _testlimitedcapi/vectorcall_limited.c
+  sources-conditional:
+    - source: _testlimitedcapi/codec.c
+      minimum-python-version: "3.14"
+    - source: _testlimitedcapi/threadstate.c
+      minimum-python-version: "3.15"
+    - source: _testlimitedcapi/version.c
+      minimum-python-version: "3.14"
+
 _testmultiphase:
   minimum-python-version: '3.10'
+  build-mode: shared
   sources:
     - _testmultiphase.c
 
 _testsinglephase:
   minimum-python-version: '3.12'
+  build-mode: shared
   sources:
     - _testsinglephase.c
 
@@ -946,18 +1082,13 @@ unicodedata:
     - unicodedata.c
 
 xxlimited:
-  # Similar story as _testcapi. The extension exists to test the limited API,
-  # which we don't really care about. Statically building it runs into problems
-  # and cross-compiling emits wrong machine type when built via setup.py.
+  # Example extension. We don't care about it.
   disabled-targets:
     - .*
 
 xxlimited_35:
   minimum-python-version: '3.10'
-
-  # Similar story as _testcapi. The extension exists to test the limited API,
-  # which we don't really care about. Statically building it runs into problems
-  # and cross-compiling emits wrong machine type when built via setup.py.
+  # Example extension. We don't care about it.
   disabled-targets:
     - .*
 

--- a/pythonbuild/cpython.py
+++ b/pythonbuild/cpython.py
@@ -274,7 +274,12 @@ def derive_setup_local(
             python_version, info.get("maximum-python-version", "100.0")
         )
 
-        if info.get("build-mode") not in (None, "shared", "static"):
+        if info.get("build-mode") not in (
+            None,
+            "shared",
+            "static",
+            "shared-or-disabled",
+        ):
             raise Exception("unsupported build-mode for extension module %s" % name)
 
         if not (python_min_match and python_max_match):
@@ -289,6 +294,11 @@ def derive_setup_local(
                     % name
                 )
                 disabled.add(name)
+
+        # Extension is demanding it be built as shared. If this isn't possible due to
+        # a static build, disable the extension.
+        if info.get("build-mode") == "shared-or-disabled" and "static" in build_options:
+            disabled.add(name)
 
         if info.get("setup-enabled", False):
             setup_enabled_wanted.add(name)
@@ -507,6 +517,11 @@ def derive_setup_local(
         section = (
             "static" if "static" in build_options else info.get("build-mode", "static")
         )
+
+        # shared-or-disabled maps to shared or disabled.
+        if section == "shared-or-disabled":
+            section = "shared"
+
         enabled_extensions[name]["build-mode"] = section
 
         # Presumably this means the extension comes from the distribution's

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -4,21 +4,21 @@
 
 use {
     crate::{json::*, macho::*},
-    anyhow::{Context, Result, anyhow},
+    anyhow::{anyhow, Context, Result},
     clap::ArgMatches,
     normalize_path::NormalizePath,
     object::{
-        Architecture, Endianness, FileKind, Object, SectionIndex, SymbolScope,
         elf::{
-            ET_DYN, ET_EXEC, FileHeader32, FileHeader64, SHN_UNDEF, STB_GLOBAL, STB_WEAK,
+            FileHeader32, FileHeader64, ET_DYN, ET_EXEC, SHN_UNDEF, STB_GLOBAL, STB_WEAK,
             STV_DEFAULT, STV_HIDDEN,
         },
-        macho::{LC_CODE_SIGNATURE, MH_OBJECT, MH_TWOLEVEL, MachHeader32, MachHeader64},
+        macho::{MachHeader32, MachHeader64, LC_CODE_SIGNATURE, MH_OBJECT, MH_TWOLEVEL},
         read::{
             elf::{Dyn, FileHeader, SectionHeader, Sym},
             macho::{LoadCommandVariant, MachHeader, Nlist, Section, Segment},
             pe::{ImageNtHeaders, PeFile, PeFile32, PeFile64},
         },
+        Architecture, Endianness, FileKind, Object, SectionIndex, SymbolScope,
     },
     once_cell::sync::Lazy,
     std::{
@@ -840,7 +840,19 @@ const GLOBAL_EXTENSIONS_WINDOWS_PRE_3_13: &[&str] = &["_msi"];
 const GLOBAL_EXTENSIONS_WINDOWS_NO_STATIC: &[&str] = &["_testinternalcapi", "_tkinter"];
 
 /// Extension modules that should be built as shared libraries.
-const SHARED_LIBRARY_EXTENSIONS: &[&str] = &["_crypt", "_ctypes_test", "_dbm", "_tkinter"];
+const SHARED_LIBRARY_EXTENSIONS: &[&str] = &[
+    "_crypt",
+    "_ctypes_test",
+    "_dbm",
+    "_testbuffer",
+    "_testcapi",
+    "_testexternalinspection",
+    "_testimportmultiple",
+    "_testlimitedcapi",
+    "_testmultiphase",
+    "_testsinglephase",
+    "_tkinter",
+];
 
 const PYTHON_VERIFICATIONS: &str = include_str!("verify_distribution.py");
 
@@ -1665,6 +1677,14 @@ fn validate_extension_modules(
             "_testmultiphase",
             "_xxtestfuzz",
         ]);
+
+        if !static_crt {
+            wanted.insert("_testcapi");
+
+            if !matches!(python_major_minor, "3.10" | "3.11" | "3.12") {
+                wanted.insert("_testlimitedcapi");
+            }
+        }
     }
 
     if (is_linux || is_macos) && matches!(python_major_minor, "3.13") {

--- a/src/verify_distribution.py
+++ b/src/verify_distribution.py
@@ -116,6 +116,22 @@ class TestPythonInterpreter(unittest.TestCase):
         for hash in wanted_hashes:
             self.assertIn(hash, hashlib.algorithms_available)
 
+    @unittest.skipIf(os.name == "nt", "_testcapi not built on Windows")
+    @unittest.skipIf(
+        os.environ["TARGET_TRIPLE"].endswith("-musl")
+        and "static" in os.environ["BUILD_OPTIONS"],
+        "_testcapi not available on statically-linked distributions",
+    )
+    def test_testcapi(self):
+        import _testcapi
+
+        self.assertIsNotNone(_testcapi)
+
+        if sys.version_info[0:2] >= (3, 13):
+            import _testlimitedcapi
+
+            self.assertIsNotNone(_testlimitedcapi)
+
     def test_sqlite(self):
         import sqlite3
 


### PR DESCRIPTION
Way back when we only supported statically linked extension modules. And we had to disable `_testcapi` and `_testlimitedcapi` because it wouldn't build statically.

Now that we support building extension modules as shared libraries, we can enable `_testcapi` and `_testlimitedcapi` as shared libraries.

This commit makes that change.

By making this change, we eliminate the largest single source of test failures. But this impact is not captured in code or CI since we currently don't run the stdlib tests in CI.

Enabling the new extensions allows tests - including PGO training tests - to exercise new code paths. This resulted in a new segfault appearing in test_bytes. Why, I'm not sure. (My best guess is it has something to do with calling variadic functions via ctypes.) This particular crash was likely a latent issue. We ignore this crashing test during PGO training as a workaround.

In order to get the extensions enabled on musl shared builds - but not static - we had to introduce some new logic to conditionally enable a shared extension on supported targets while automatically disabling on static targets. There may be a cleaner way to express this semantic intent. But the implemented solution does work.