### PR TITLE
Bump the year in the example release version in the dispatch input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "The version to release (e.g., '20250414')."
+        description: "The version to release (e.g., '20260414')."
         type: string
       sha:
         description: "The full SHA of the commit to be released (e.g., 'd09ff921d92d6da8d8a608eaa850dc8c0f638194')."


### PR DESCRIPTION
See https://github.com/astral-sh/python-build-standalone/issues/1030