### PR TITLE
remove pip from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 14
-    groups:
-      python:
-        patterns:
-          - "*"
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:


### PR DESCRIPTION
Python related package updates are now specified in the uv.lock file which should be updated using `uv sync`