### PR TITLE
Reduce the AWS artifact upload concurrency and increase retries

### DIFF
--- a/src/s3.rs
+++ b/src/s3.rs
@@ -14,6 +14,13 @@ use {
     },
 };
 
+/// Maximum number of concurrent S3 uploads.
+const UPLOAD_CONCURRENCY: usize = 4;
+
+/// Maximum number of attempts per S3 request (includes the initial attempt).
+/// The AWS SDK uses exponential backoff with jitter between attempts.
+const S3_MAX_ATTEMPTS: u32 = 5;
+
 /// Upload a single file to S3 under `key`, setting an immutable cache-control header.
 async fn upload_s3_file(
     s3: &aws_sdk_s3::Client,
@@ -32,9 +39,9 @@ async fn upload_s3_file(
         return Ok(());
     }
     // A single PUT is sufficient here: individual artifacts are well under the 5 GB
-    // single-request limit, and we already upload up to 8 files concurrently, so
-    // splitting each file into multipart chunks would add complexity without
-    // meaningfully improving throughput.
+    // single-request limit, and we already upload up to UPLOAD_CONCURRENCY files
+    // concurrently, so splitting each file into multipart chunks would add complexity
+    // without meaningfully improving throughput.
     let body = ByteStream::from_path(path).await?;
     s3.put_object()
         .bucket(bucket)
@@ -101,11 +108,16 @@ pub async fn command_upload_mirror_distributions(args: &ArgMatches) -> Result<()
 
     // Initialise the AWS S3 client. Credentials and endpoint are read from the standard
     // AWS environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
-    // AWS_ENDPOINT_URL, AWS_DEFAULT_REGION)
+    // AWS_ENDPOINT_URL, AWS_DEFAULT_REGION).
+    let retry_config =
+        aws_sdk_s3::config::retry::RetryConfig::standard().with_max_attempts(S3_MAX_ATTEMPTS);
     let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
-    let s3 = aws_sdk_s3::Client::new(&config);
+    let s3_config = aws_sdk_s3::config::Builder::from(&config)
+        .retry_config(retry_config)
+        .build();
+    let s3 = aws_sdk_s3::Client::from_conf(s3_config);
 
-    // Upload all files concurrently (up to 8 in-flight at a time).
+    // Upload all files concurrently (up to UPLOAD_CONCURRENCY in-flight at a time).
     let upload_futs = wanted_filenames
         .iter()
         .filter(|(source, _)| filenames.contains(*source))
@@ -118,7 +130,7 @@ pub async fn command_upload_mirror_distributions(args: &ArgMatches) -> Result<()
         });
 
     futures::stream::iter(upload_futs)
-        .buffer_unordered(8)
+        .buffer_unordered(UPLOAD_CONCURRENCY)
         .try_collect::<Vec<_>>()
         .await?;
 


### PR DESCRIPTION
Attempting to resolve release failures

```
     Running `target/release/pythonbuild upload-mirror-distributions --dist dist --datetime 20260324T0736 --tag 20260324 --bucket *** --prefix github/python-build-standalone/releases/download/20260324/`
found all 852 release artifacts
uploading cpython-3.10.20-aarch64-apple-darwin-debug-20260324T0736.tar.zst -> s3://***/github/python-build-standalone/releases/download/20260324/cpython-3.10.20+20260324-aarch64-apple-darwin-debug-full.tar.zst
uploading cpython-3.10.20-aarch64-apple-darwin-install_only-20260324T0736.tar.gz -> s3://***/github/python-build-standalone/releases/download/20260324/cpython-3.10.20+20260324-aarch64-apple-darwin-install_only.tar.gz
uploading cpython-3.10.20-aarch64-apple-darwin-install_only_stripped-20260324T0736.tar.gz -> s3://***/github/python-build-standalone/releases/download/20260324/cpython-3.10.20+20260324-aarch64-apple-darwin-install_only_stripped.tar.gz
uploading cpython-3.10.20-aarch64-apple-darwin-pgo+lto-20260324T0736.tar.zst -> s3://***/github/python-build-standalone/releases/download/20260324/cpython-3.10.20+20260324-aarch64-apple-darwin-pgo+lto-full.tar.zst
uploading cpython-3.10.20-aarch64-unknown-linux-gnu-debug-20260324T0736.tar.zst -> s3://***/github/python-build-standalone/releases/download/20260324/cpython-3.10.20+20260324-aarch64-unknown-linux-gnu-debug-full.tar.zst
uploading cpython-3.10.20-aarch64-unknown-linux-gnu-install_only-20260324T0736.tar.gz -> s3://***/github/python-build-standalone/releases/download/20260324/cpython-3.10.20+20260324-aarch64-unknown-linux-gnu-install_only.tar.gz
uploading cpython-3.10.20-aarch64-unknown-linux-gnu-install_only_stripped-20260324T0736.tar.gz -> s3://***/github/python-build-standalone/releases/download/20260324/cpython-3.10.20+20260324-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz
uploading cpython-3.10.20-aarch64-unknown-linux-gnu-pgo+lto-20260324T0736.tar.zst -> s3://***/github/python-build-standalone/releases/download/20260324/cpython-3.10.20+20260324-aarch64-unknown-linux-gnu-pgo+lto-full.tar.zst
Error: dispatch failure

Caused by:
    0: io error
    1: client error (SendRequest)
    2: connection error
    3: Connection reset by peer (os error 104)
error: Recipe `release-upload-mirror` failed with exit code 1
```