### PR TITLE
Fix bug in `release-set-latest-release` where `main` is not restored when update is already made

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -60,12 +60,12 @@ release-set-latest-release tag:
   if ! git diff --quiet; then
     git add latest-release.json
     git commit -m 'set latest release to {{tag}}'
-    git switch main
-
     git push origin latest-release
   else
     echo "No changes to commit."
   fi
+
+  git switch main
 
 # Create a GitHub release object, or reuse an existing prerelease.
 release-create tag:


### PR DESCRIPTION
This caused the following failure when retrying an interrupted release

```
Run just release-upload-mirror \
error: No justfile found
Error: Process completed with exit code 1.
```

 https://github.com/astral-sh/python-build-standalone/actions/runs/23459592334/job/68261628113
 
 The logs are incriminating
 
 ```
 + git switch latest-release
Switched to a new branch 'latest-release'
branch 'latest-release' set up to track 'origin/latest-release'.
+ git reset --hard origin/latest-release
HEAD is now at 50d925d5 set latest release to 20260324
+ cat
+ git diff --quiet
+ echo 'No changes to commit.'
No changes to commit.
```

We failed to return to the `main` branch