### PR TITLE
ci: disable compression of uploaded distribution artifacts

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -311,6 +311,7 @@ jobs:
         with:
           name: cpython-${{ matrix.python }}-${{ matrix.target_triple }}-${{ matrix.build_options }}
           path: dist/*
+          compression-level: '0'
 
       - name: Validate Distribution
         if: ${{ ! matrix.dry-run }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,7 +2,7 @@ name: macos
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
 
 concurrency:
@@ -12,7 +12,7 @@ concurrency:
 env:
   FORCE_COLOR: 1
 
-permissions: {}
+permissions: { }
 
 jobs:
   crate-build:
@@ -162,6 +162,7 @@ jobs:
         with:
           name: cpython-${{ matrix.python }}-${{ matrix.target_triple }}-${{ matrix.build_options }}
           path: dist/*
+          compression-level: '0'
 
       - name: Checkout macOS SDKs for validation
         if: ${{ ! matrix.dry-run }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,7 @@ name: windows
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
 
 concurrency:
@@ -12,7 +12,7 @@ concurrency:
 env:
   FORCE_COLOR: 1
 
-permissions: {}
+permissions: { }
 
 jobs:
   crate-build:
@@ -179,6 +179,7 @@ jobs:
         with:
           name: cpython-${{ matrix.python }}-${{ matrix.vcvars }}-${{ matrix.build_options }}
           path: dist/*
+          compression-level: '0'
 
       - name: Validate Distribution
         if: ${{ ! matrix.dry-run }}


### PR DESCRIPTION
`actions/upload-artifact` uploads a zip archive and applies default zlib compression level 6 to files by default.

The uploaded PBS distribution artifacts are already zstd compressed. zlib compression will achieve nothing and waste CPU cycles on both upload and download.

Disable compression on these artifacts.

I audited all uses of `actions/upload-artifact` and confirmed that compression is disabled when appropriate (it was already disabled on the container image artifacts, which are also zstd compressed).