### PR TITLE
Move `test-distribution.py` logic into `pythonbuild`, use `uv`

### DIFF
--- a/pythonbuild/testdist.py
+++ b/pythonbuild/testdist.py
@@ -1,0 +1,65 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import argparse
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+from .utils import extract_python_archive
+
+
+def run_stdlib_tests(dist_root: Path, python_info, harness_args: list[str]) -> int:
+    """Run Python stdlib tests for a PBS distribution.
+
+    The passed path is the `python` directory from the extracted distribution
+    archive.
+    """
+    args = [
+        str(dist_root / python_info["python_exe"]),
+        str(dist_root / python_info["run_tests"]),
+    ]
+
+    args.extend(harness_args)
+
+    return subprocess.run(args).returncode
+
+
+def main(raw_args: list[str]) -> int:
+    """test-distribution.py functionality."""
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "dist",
+        nargs=1,
+        help="Path to distribution to test",
+    )
+    parser.add_argument(
+        "harness_args",
+        nargs=argparse.REMAINDER,
+        help="Raw arguments to pass to Python's test harness",
+    )
+
+    args = parser.parse_args(raw_args)
+
+    dist_path_raw = Path(args.dist[0])
+
+    td = None
+    try:
+        if dist_path_raw.is_file():
+            td = tempfile.TemporaryDirectory()
+            dist_path = extract_python_archive(dist_path_raw, Path(td.name))
+        else:
+            dist_path = dist_path_raw
+
+        python_json = dist_path / "PYTHON.json"
+
+        with python_json.open("r", encoding="utf-8") as fh:
+            python_info = json.load(fh)
+
+        return run_stdlib_tests(dist_path, python_info, args.harness_args)
+    finally:
+        if td:
+            td.cleanup()

--- a/pythonbuild/utils.py
+++ b/pythonbuild/utils.py
@@ -510,6 +510,24 @@ def compress_python_archive(
     return dest_path
 
 
+def extract_python_archive(
+    archive: pathlib.Path, dest_dir: pathlib.Path
+) -> pathlib.Path:
+    """Extract a PBS .tar.zst distribution archive to the given directory.
+
+    Returns the path to the `python` directory, which is equivalent to
+    `dest_dir / "python"`.
+    """
+    with archive.open("rb") as fh:
+        dctx = zstandard.ZstdDecompressor()
+        with dctx.stream_reader(fh) as reader:
+            with tarfile.open(mode="r|", fileobj=reader) as tf:
+                dest_dir.mkdir(exist_ok=True, parents=True)
+                tf.extractall(dest_dir)
+
+    return dest_dir / "python"
+
+
 def add_licenses_to_extension_entry(entry):
     """Add licenses keys to a ``extensions`` entry for JSON distribution info."""
 

--- a/test-distribution.py
+++ b/test-distribution.py
@@ -1,52 +1,19 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 """Script to run Python tests from a distribution archive."""
 
-import json
-import pathlib
-import subprocess
 import sys
-import tarfile
-import tempfile
 
-import zstandard
-
-
-def main(args):
-    if not args:
-        print("Usage: test-distribution.py path/to/distribution.tar.zst")
-        return 1
-
-    distribution_path = args[0]
-
-    with tempfile.TemporaryDirectory() as td:
-        td = pathlib.Path(td)
-
-        with open(distribution_path, "rb") as fh:
-            dctx = zstandard.ZstdDecompressor()
-            with dctx.stream_reader(fh) as reader:
-                with tarfile.open(mode="r|", fileobj=reader) as tf:
-                    tf.extractall(td)
-
-        root = td / "python"
-
-        python_json = root / "PYTHON.json"
-
-        with python_json.open("rb") as fh:
-            info = json.load(fh)
-
-        test_args = [
-            str(root / info["python_exe"]),
-            str(root / info["run_tests"]),
-        ]
-
-        test_args.extend(args[1:])
-
-        return subprocess.run(test_args).returncode
-
+from pythonbuild.testdist import main
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    # Unbuffer stdout.
+    sys.stdout.reconfigure(line_buffering=True)
+
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except KeyboardInterrupt:
+        sys.exit(1)


### PR DESCRIPTION
I'm planning to introduce running of the full stdlib test harness into CI.

As a prerequisite to this work, I want to shore up the running of tests against the Python distribution.

Right now, we have a mechanism in `test-distribution.py` to extract the distribution and run the stdlib test harness.

This commit moves and modernizes the logic so it resides in `pythonbuild`. `test-distribution.py` is switched to use `uv`, matching other scripts in the root directory.

Future commits will significantly refactor this code for testing distribution, including unifying the Rust-based `verify_distribution.py` into the now `pythonbuild` based testing mechanism.