### PR TITLE
ci: run `test-distribution.py` with `uv run --no-dev`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -186,4 +186,4 @@ jobs:
         run: |
           $Dists = Resolve-Path -Path "dist/*.tar.zst" -Relative
           .\pythonbuild.exe validate-distribution $Dists
-          uv run test-distribution.py $Dists
+          uv run --no-dev test-distribution.py $Dists


### PR DESCRIPTION
Otherwise we run into a build issue with `cryptography` on Windows ARM.

This should fix CI on the `main` branch.