### PR TITLE
include noexecstack hardening flag on Linux

### DIFF
--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -136,6 +136,9 @@ aarch64-unknown-linux-gnu:
     - '-mno-omit-leaf-frame-pointer'
     # Needed to prevent BOLT from crashing.
     - '-fdebug-default-version=4'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -575,6 +578,9 @@ x86_64-unknown-linux-gnu:
     - '-mno-omit-leaf-frame-pointer'
     # Needed to prevent BOLT from crashing.
     - '-fdebug-default-version=4'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -625,6 +631,9 @@ x86_64_v2-unknown-linux-gnu:
     - '-mno-omit-leaf-frame-pointer'
     # Needed to prevent BOLT from crashing.
     - '-fdebug-default-version=4'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -675,6 +684,9 @@ x86_64_v3-unknown-linux-gnu:
     - '-mno-omit-leaf-frame-pointer'
     # Needed to prevent BOLT from crashing.
     - '-fdebug-default-version=4'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -725,6 +737,9 @@ x86_64_v4-unknown-linux-gnu:
     - '-mno-omit-leaf-frame-pointer'
     # Needed to prevent BOLT from crashing.
     - '-fdebug-default-version=4'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -772,6 +787,9 @@ x86_64-unknown-linux-musl:
     # Enable frame pointers
     - '-fno-omit-frame-pointer'
     - '-mno-omit-leaf-frame-pointer'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -820,6 +838,9 @@ x86_64_v2-unknown-linux-musl:
     # Enable frame pointers
     - '-fno-omit-frame-pointer'
     - '-mno-omit-leaf-frame-pointer'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -868,6 +889,9 @@ x86_64_v3-unknown-linux-musl:
     # Enable frame pointers
     - '-fno-omit-frame-pointer'
     - '-mno-omit-leaf-frame-pointer'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -916,6 +940,9 @@ x86_64_v4-unknown-linux-musl:
     # Enable frame pointers
     - '-fno-omit-frame-pointer'
     - '-mno-omit-leaf-frame-pointer'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -967,6 +994,9 @@ aarch64-unknown-linux-musl:
     # Enable frame pointers
     - '-fno-omit-frame-pointer'
     - '-mno-omit-leaf-frame-pointer'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb


### PR DESCRIPTION
Mark the stack memory as non-executable using the '-Wl,-z,noexecstack' flag on aarch64 and x86_64 linux platforms.

Other linux targets are cross-compiled, this flag is left off for the time being.

closes #1061