### PR TITLE
remove -use-gnu-stack from BOLT flags

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -257,6 +257,12 @@ if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_12}" ]; then
     else
         patch -p1 -i "${ROOT}/patch-configure-bolt-skip-funcs.patch"
     fi
+
+    # Remove -use-gnu-stack from the BOLT optimization flags as it incorrectly
+    # removes the PT_GNU_STACK segment. This patch can be removed when this bug
+    # is fixed in LLVM.
+    # https://github.com/llvm/llvm-project/issues/174191
+    patch -p1 -i "${ROOT}/patch-configure-bolt-remove-use-gnu-stack.patch"
 fi
 
 # The optimization make targets are both phony and non-phony. This leads

--- a/cpython-unix/patch-configure-bolt-remove-use-gnu-stack.patch
+++ b/cpython-unix/patch-configure-bolt-remove-use-gnu-stack.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index a1f4a567095..03264f87d4c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2205,7 +2205,6 @@ then
+      -inline-ap
+      -indirect-call-promotion=all
+      -dyno-stats
+-     -use-gnu-stack
+      -frame-opt=hot
+    ")]
+   )


### PR DESCRIPTION
Remove -use-gnu-stack from the BOLT flags used to optimize CPython as it incorrectly removes the PT_GNU_STACK segment causing glibc to default to an executable stack, for example when creating a new thread.

This can be reverted when https://github.com/llvm/llvm-project/issues/174191 is fixed in LLVM

Should be applied after #1064 

closes #956