### PR TITLE
Use a page size of 1 for release retrieval

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -180,6 +180,7 @@ async fn get_draft_release_by_tag(
         .repos(organization, repo)
         .releases()
         .list()
+        .per_page(1)
         .send()
         .await?;
 


### PR DESCRIPTION
The default page size times out server side after 10s.

A page size of 5 takes 2s. We can generally expect this to be the latest release though, so 1 per page seems fine.

Alternatively, we could persist and propagate the draft release id, but this seems fine for now.