### PR TITLE
link with noexecstack when cross-compiling

### DIFF
--- a/cpython-unix/build-tcl.sh
+++ b/cpython-unix/build-tcl.sh
@@ -67,7 +67,7 @@ rm -rf pkgs/sqlite* pkgs/tdbc*
 pushd unix
 
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC -I${TOOLS_PATH}/deps/include"
-LDFLAGS="${EXTRA_TARGET_CFLAGS} -L${TOOLS_PATH}/deps/lib"
+LDFLAGS="${EXTRA_TARGET_LDFLAGS} -L${TOOLS_PATH}/deps/lib"
 if [[ "${PYBUILD_PLATFORM}" != macos* ]]; then
     LDFLAGS="${LDFLAGS} -Wl,--exclude-libs,ALL"
 fi

--- a/cpython-unix/build-tcl.sh
+++ b/cpython-unix/build-tcl.sh
@@ -77,7 +77,8 @@ fi
 # Export compiler flags to make them available when configuring and building
 # these packages.
 # An alternative is to include these when calling ./configure AND make
-export CFLAGS CPPFLAGS LDFLAGS
+export CFLAGS LDFLAGS
+export CPPFLAGS="${CFLAGS}"
 
 ./configure \
     --build="${BUILD_TRIPLE}" \

--- a/cpython-unix/build-tcl.sh
+++ b/cpython-unix/build-tcl.sh
@@ -77,9 +77,7 @@ fi
 # Export compiler flags to make them available when configuring and building
 # these packages.
 # An alternative is to include these when calling ./configure AND make
-export CFLAGS="${CFLAGS}"
-export CPPFLAGS="${CFLAGS}"
-export LDFLAGS="${LDFLAGS}"
+export CFLAGS CPPFLAGS LDFLAGS
 
 ./configure \
     --build="${BUILD_TRIPLE}" \

--- a/cpython-unix/build-tcl.sh
+++ b/cpython-unix/build-tcl.sh
@@ -72,7 +72,16 @@ if [[ "${PYBUILD_PLATFORM}" != macos* ]]; then
     LDFLAGS="${LDFLAGS} -Wl,--exclude-libs,ALL"
 fi
 
-CFLAGS="${CFLAGS}" CPPFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ./configure \
+# Tcl configures and builds packages (itcl, threads, ...) as make targets.
+# These do not pick up environment variables passed to ./configure
+# Export compiler flags to make them available when configuring and building
+# these packages.
+# An alternative is to include these when calling ./configure AND make
+export CFLAGS="${CFLAGS}"
+export CPPFLAGS="${CFLAGS}"
+export LDFLAGS="${LDFLAGS}"
+
+./configure \
     --build="${BUILD_TRIPLE}" \
     --host="${TARGET_TRIPLE}" \
     --prefix=/tools/deps \

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -185,6 +185,9 @@ armv7-unknown-linux-gnueabi:
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/arm-linux-gnueabi-gcc
   target_cxx: /usr/bin/arm-linux-gnueabi-g++
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -226,6 +229,9 @@ armv7-unknown-linux-gnueabihf:
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/arm-linux-gnueabihf-gcc
   target_cxx: /usr/bin/arm-linux-gnueabihf-g++
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -266,6 +272,9 @@ loongarch64-unknown-linux-gnu:
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/loongarch64-linux-gnu-gcc
   target_cxx: /usr/bin/loongarch64-linux-gnu-g++
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -307,6 +316,9 @@ mips-unknown-linux-gnu:
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/mips-linux-gnu-gcc
   target_cxx: /usr/bin/mips-linux-gnu-g++
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -348,6 +360,9 @@ mipsel-unknown-linux-gnu:
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/mipsel-linux-gnu-gcc
   target_cxx: /usr/bin/mipsel-linux-gnu-g++
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -389,6 +404,9 @@ ppc64le-unknown-linux-gnu:
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/powerpc64le-linux-gnu-gcc
   target_cxx: /usr/bin/powerpc64le-linux-gnu-g++
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -430,6 +448,9 @@ riscv64-unknown-linux-gnu:
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
   target_cc: /usr/bin/riscv64-linux-gnu-gcc
   target_cxx: /usr/bin/riscv64-linux-gnu-g++
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb
@@ -474,6 +495,9 @@ s390x-unknown-linux-gnu:
   target_cflags:
     # set the minimum compatibility level to z10 (released 2008)
     - '-march=z10'
+  target_ldflags:
+    # Hardening
+    - '-Wl,-z,noexecstack'
   needs:
     - autoconf
     - bdb

--- a/pythonbuild/downloads.py
+++ b/pythonbuild/downloads.py
@@ -212,7 +212,8 @@ DOWNLOADS = {
         "version": "1.4.19",
     },
     "mpdecimal": {
-        "url": "https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-4.0.0.tar.gz",
+        # Mirrored from https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-4.0.0.tar.gz
+        "url": "https://astral-sh.github.io/mirror/files/mpdecimal-4.0.0.tar.gz",
         "size": 315325,
         "sha256": "942445c3245b22730fd41a67a7c5c231d11cb1b9936b9c0f76334fb7d0b4468c",
         "version": "4.0.0",


### PR DESCRIPTION
Explicitly disable an executable stack on all Linux targets, even when cross-compiling.

Follow up to test failures cased by #1070