### PR TITLE
Run a small subset of targets on pull requests w/o labels

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -178,6 +178,7 @@ jobs:
             --platform linux \
             --labels "${STEPS_GET_LABELS_OUTPUTS_LABELS}" \
             --max-shards 2 \
+            --event ${{ github.event_name }} \
             ${{ (steps.check-pythonbuild.outputs.changed == 'true' || github.ref == 'refs/heads/main') && '--force-crate-build' || '' }} \
             > matrix.json
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Generate build matrix
         id: set-matrix
         run: |
-          uv run ci-matrix.py --platform darwin --labels "${STEPS_GET_LABELS_OUTPUTS_LABELS}" ${{ (steps.check-pythonbuild.outputs.changed == 'true' || github.ref == 'refs/heads/main') && '--force-crate-build' || '' }} > matrix.json
+          uv run ci-matrix.py --platform darwin --labels "${STEPS_GET_LABELS_OUTPUTS_LABELS}" --event ${{ github.event_name }} ${{ (steps.check-pythonbuild.outputs.changed == 'true' || github.ref == 'refs/heads/main') && '--force-crate-build' || '' }} > matrix.json
 
           # Extract python-build matrix
           echo "matrix=$(jq -c '."python-build"' matrix.json)" >> $GITHUB_OUTPUT

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Generate build matrix
         id: set-matrix
         run: |
-          uv run ci-matrix.py --platform windows --labels "${STEPS_GET_LABELS_OUTPUTS_LABELS}" ${{ (steps.check-pythonbuild.outputs.changed == 'true' || github.ref == 'refs/heads/main') && '--force-crate-build' || '' }} > matrix.json
+          uv run ci-matrix.py --platform windows --labels "${STEPS_GET_LABELS_OUTPUTS_LABELS}" --event ${{ github.event_name }} ${{ (steps.check-pythonbuild.outputs.changed == 'true' || github.ref == 'refs/heads/main') && '--force-crate-build' || '' }} > matrix.json
 
           # Extract python-build matrix
           echo "matrix=$(jq -c '."python-build"' matrix.json)" >> $GITHUB_OUTPUT

--- a/ci-matrix.py
+++ b/ci-matrix.py
@@ -15,6 +15,7 @@ import yaml
 from packaging.version import Version
 
 CI_TARGETS_YAML = "ci-targets.yaml"
+CI_TARGETS_PULL_REQUEST_NO_LABELS = "ci-targets-pull-request-no-labels.yaml"
 CI_RUNNERS_YAML = "ci-runners.yaml"
 CI_EXTRA_SKIP_LABELS = ["documentation"]
 CI_MATRIX_SIZE_LIMIT = 256  # The maximum size of a matrix in GitHub Actions
@@ -344,6 +345,11 @@ def parse_args() -> argparse.Namespace:
         help="Comma-separated list of labels to filter by (e.g., 'platform:darwin,python:3.13,build:debug'), all must match.",
     )
     parser.add_argument(
+        "--event",
+        choices=["pull_request", "push"],
+        help="The GitHub event type. When 'pull_request', uses ci-defaults.yaml for the default subset.",
+    )
+    parser.add_argument(
         "--free-runners",
         action="store_true",
         help="If only free runners should be used.",
@@ -366,7 +372,11 @@ def main() -> None:
     args = parse_args()
     labels = parse_labels(args.labels)
 
-    with open(CI_TARGETS_YAML) as f:
+    if args.event == "pull_request" and not any(labels.values()):
+        config_yaml = CI_TARGETS_PULL_REQUEST_NO_LABELS
+    else:
+        config_yaml = CI_TARGETS_YAML
+    with open(config_yaml) as f:
         config = yaml.safe_load(f)
 
     with open(CI_RUNNERS_YAML) as f:

--- a/ci-targets-pull-request-no-labels.yaml
+++ b/ci-targets-pull-request-no-labels.yaml
@@ -1,0 +1,53 @@
+# Describes the targets that the CI system will build on a pull request if no labels are specified
+# This is a subset of the targets from ci-targets.yaml
+
+darwin:
+  aarch64-apple-darwin:
+    arch: aarch64
+    python_versions:
+      - "3.14"
+    build_options:
+      - pgo+lto
+
+linux:
+  armv7-unknown-linux-gnueabihf:
+    arch: armv7
+    libc: gnu
+    python_versions:
+      - "3.14"
+    build_options:
+      - lto
+
+  x86_64-unknown-linux-gnu:
+    arch: x86_64
+    libc: gnu
+    python_versions:
+      - "3.14"
+    build_options:
+      - pgo+lto
+      - freethreaded+pgo+lto
+    run: true
+
+  x86_64-unknown-linux-musl:
+    arch: x86_64
+    libc: musl
+    python_versions:
+      - "3.14"
+    build_options:
+      - lto+static
+      - lto
+      - freethreaded+lto
+    run: true
+
+windows:
+  x86_64-pc-windows-msvc:
+    arch: x86_64
+    vcvars: vcvars64.bat
+    python_versions:
+      - "3.14"
+    vs_version: "2022"
+    vs_version_override_conditional:
+      vs_version: "2026"
+      minimum-python-version: "3.15"
+    build_options:
+      - pgo


### PR DESCRIPTION
Alternative to #1075.

Run a small subset of targets on pull requests when no labels are specified.

If labels are specified they filter the full set of targets.

On a push all targets are run.

Running all targets on a pull request requires using multiple labels, for example `platform:linux`, `platform:darwin`, `platform:windows`.