### PR TITLE
remove tcl/tk translations and demo files from distributions

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -1379,6 +1379,10 @@ fi
 # Prune the tk demos which are > 1 MB and not used
 rm -rf "${ROOT}/out/python/install/lib/tk9.0/demos"
 
+# Prune the tcl/tk translations
+rm -rf "${ROOT}/out/python/install/lib/tcl9.0/msgs"
+rm -rf "${ROOT}/out/python/install/lib/tk9.0/msgs"
+
 # Copy the terminfo database if present.
 if [ -d "${TOOLS_PATH}/deps/usr/share/terminfo" ]; then
   cp -av "${TOOLS_PATH}/deps/usr/share/terminfo" "${ROOT}/out/python/install/share/"

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -1376,6 +1376,9 @@ if [ -d "${TOOLS_PATH}/deps/lib/tcl9" ]; then
     )
 fi
 
+# Prune the tk demos which are > 1 MB and not used
+rm -rf "${ROOT}/out/python/install/lib/tk9.0/demos"
+
 # Copy the terminfo database if present.
 if [ -d "${TOOLS_PATH}/deps/usr/share/terminfo" ]; then
   cp -av "${TOOLS_PATH}/deps/usr/share/terminfo" "${ROOT}/out/python/install/share/"


### PR DESCRIPTION
Remove the Tcl/Tk translation files (.msg) and the Tk demos from the distribution artifacts. The former would only be needed in edge cases and the later is never be needed.

closes #1095 