### PR TITLE
Force patchelf to use 64KB page size on loongarch64

### DIFF
--- a/cpython-unix/build-patchelf.sh
+++ b/cpython-unix/build-patchelf.sh
@@ -13,6 +13,37 @@ tar -xf "patchelf-${PATCHELF_VERSION}.tar.bz2"
 
 pushd patchelf-0.13.1.20211127.72b6d44
 
+# TODO: Drop this patch once patchelf is updated to 0.14.0 or newer,
+# which includes native LoongArch64 support.
+# See: https://github.com/astral-sh/python-build-standalone/issues/1106
+if [[ "${TARGET_TRIPLE}" = loongarch64* ]]; then
+    patch -p1 << 'EOF'
+diff --git a/src/patchelf.cc b/src/patchelf.cc
+index 2b7ec8b9..06f41c6f 100644
+--- a/src/patchelf.cc
++++ b/src/patchelf.cc
+@@ -57,6 +57,10 @@ static int forcedPageSize = DEFAULT_PAGESIZE;
+ static int forcedPageSize = -1;
+ #endif
+ 
++#ifndef EM_LOONGARCH
++#define EM_LOONGARCH    258
++#endif
++
+ using FileContents = std::shared_ptr<std::vector<unsigned char>>;
+ 
+ #define ElfFileParams class Elf_Ehdr, class Elf_Phdr, class Elf_Shdr, class Elf_Addr, class Elf_Off, class Elf_Dyn, class Elf_Sym, class Elf_Verneed, class Elf_Versym
+@@ -460,6 +464,7 @@ unsigned int ElfFile<ElfFileParamNames>::getPageSize() const
+       case EM_PPC64:
+       case EM_AARCH64:
+       case EM_TILEGX:
++      case EM_LOONGARCH:
+         return 0x10000;
+       default:
+         return 0x1000;
+EOF
+fi
+
 CC="${HOST_CC}" CXX="${HOST_CXX}" CFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" CPPFLAGS="${EXTRA_HOST_CFLAGS} -fPIC" \
     ./configure \
         --build="${BUILD_TRIPLE}" \

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -267,6 +267,7 @@ loongarch64-unknown-linux-gnu:
     - '3.12'
     - '3.13'
     - '3.14'
+    - '3.15'
   docker_image_suffix: .cross-loongarch64
   host_cc: /usr/bin/x86_64-linux-gnu-gcc
   host_cxx: /usr/bin/x86_64-linux-gnu-g++
@@ -275,6 +276,7 @@ loongarch64-unknown-linux-gnu:
   target_ldflags:
     # Hardening
     - '-Wl,-z,noexecstack'
+    - '-Wl,-z,max-page-size=0x10000'
   needs:
     - autoconf
     - bdb


### PR DESCRIPTION
This patch addresses a segmentation fault issue on `LoongArch64` platforms caused by incorrect ELF segment alignment during the build process.

- fix: #1106 