### PR TITLE
cross compile riscv64 with LLVM toolchain and sysroot

### DIFF
--- a/cpython-unix/build.cross-riscv64.Dockerfile
+++ b/cpython-unix/build.cross-riscv64.Dockerfile
@@ -29,11 +29,12 @@ RUN for s in debian_buster debian_buster-updates debian-security_buster/updates;
 
 RUN apt-get update
 
-# Host building.
+# Build tools, same as in build.Dockerfile
 RUN apt-get install \
     bzip2 \
-    gcc \
-    g++ \
+    ca-certificates \
+    curl \
+    file \
     libc6-dev \
     libffi-dev \
     make \
@@ -46,32 +47,15 @@ RUN apt-get install \
     zip \
     zlib1g-dev
 
-# Cross-building.
+# riscv64 sysroot and host binutils for the riscv64-linux-gnu target
 RUN apt-get install \
-    g++-aarch64-linux-gnu \
-    g++-arm-linux-gnueabi \
-    g++-arm-linux-gnueabihf \
-    g++-mips-linux-gnu \
-    g++-mips64el-linux-gnuabi64 \
-    g++-mipsel-linux-gnu \
-    g++-powerpc64le-linux-gnu \
-    g++-riscv64-linux-gnu \
-    g++-s390x-linux-gnu \
-    gcc-aarch64-linux-gnu \
-    gcc-arm-linux-gnueabi \
-    gcc-arm-linux-gnueabihf \
-    gcc-mips-linux-gnu \
-    gcc-mips64el-linux-gnuabi64 \
-    gcc-mipsel-linux-gnu \
-    gcc-powerpc64le-linux-gnu \
-    gcc-riscv64-linux-gnu \
-    gcc-s390x-linux-gnu \
-    libc6-dev-arm64-cross \
-    libc6-dev-armel-cross \
-    libc6-dev-armhf-cross \
-    libc6-dev-mips-cross \
-    libc6-dev-mips64el-cross \
-    libc6-dev-mipsel-cross \
-    libc6-dev-ppc64el-cross \
+    binutils-riscv64-linux-gnu \
+    libc6-riscv64-cross \
     libc6-dev-riscv64-cross \
-    libc6-dev-s390x-cross
+    linux-libc-dev-riscv64-cross \
+    libgcc1-riscv64-cross \
+    libgcc-8-dev-riscv64-cross
+
+# target specific symlinks to cross-compile using external LLVM toolchain
+RUN ln -s /tools/llvm/bin/clang /usr/bin/riscv64-linux-gnu-clang && \
+    ln -s /tools/llvm/bin/clang++ /usr/bin/riscv64-linux-gnu-clang++

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -443,11 +443,12 @@ riscv64-unknown-linux-gnu:
     - '3.13'
     - '3.14'
     - '3.15'
+  needs_toolchain: true
   docker_image_suffix: .cross-riscv64
-  host_cc: /usr/bin/x86_64-linux-gnu-gcc
-  host_cxx: /usr/bin/x86_64-linux-gnu-g++
-  target_cc: /usr/bin/riscv64-linux-gnu-gcc
-  target_cxx: /usr/bin/riscv64-linux-gnu-g++
+  host_cc: clang
+  host_cxx: clang++
+  target_cc: /usr/bin/riscv64-linux-gnu-clang
+  target_cxx: /usr/bin/riscv64-linux-gnu-clang++
   target_ldflags:
     # Hardening
     - '-Wl,-z,noexecstack'


### PR DESCRIPTION
Use the same LLVM toolchain that is used for native x86-64 builds to cross compile for riscv64 using a sysroot.