### PR TITLE
bundle fallback Root Certificates

### DIFF
--- a/cpython-unix/Makefile
+++ b/cpython-unix/Makefile
@@ -254,7 +254,7 @@ PYTHON_DEPENDS_$(1) := \
     $$(if$$(NEED_AUTOCONF),$$(OUTDIR)/autoconf-$$(AUTOCONF_VERSION)-$$(PACKAGE_SUFFIX).tar) \
     $$(if $$(NEED_BDB),$$(OUTDIR)/bdb-$$(BDB_VERSION)-$$(PACKAGE_SUFFIX).tar) \
     $$(if $$(NEED_BZIP2),$$(OUTDIR)/bzip2-$$(BZIP2_VERSION)-$$(PACKAGE_SUFFIX).tar) \
-    $$(OUTDIR)/certifi-$$(CERTIFI_VERSION)-$$(PACKAGE_SUFFIX).tar \
+    $$(if $$(NEED_CERTIFI),$$(OUTDIR)/certifi-$$(CERTIFI_VERSION)-$$(PACKAGE_SUFFIX).tar) \
     $$(if $$(NEED_EXPAT),$$(OUTDIR)/expat-$$(EXPAT_VERSION)-$$(PACKAGE_SUFFIX).tar) \
     $$(if $$(NEED_LIBEDIT),$$(OUTDIR)/libedit-$$(LIBEDIT_VERSION)-$$(PACKAGE_SUFFIX).tar) \
     $$(if $$(NEED_LIBFFI_3_3),$$(OUTDIR)/libffi-3.3-$$(LIBFFI_3.3_VERSION)-$$(PACKAGE_SUFFIX).tar) \

--- a/cpython-unix/Makefile
+++ b/cpython-unix/Makefile
@@ -116,6 +116,9 @@ $(OUTDIR)/bdb-$(BDB_VERSION)-$(PACKAGE_SUFFIX).tar: $(PYTHON_DEP_DEPENDS) $(HERE
 $(OUTDIR)/bzip2-$(BZIP2_VERSION)-$(PACKAGE_SUFFIX).tar: $(PYTHON_DEP_DEPENDS) $(HERE)/build-bzip2.sh
 	$(RUN_BUILD) --docker-image $(DOCKER_IMAGE_BUILD) bzip2
 
+$(OUTDIR)/certifi-$(CERTIFI_VERSION)-$(PACKAGE_SUFFIX).tar: $(PYTHON_DEP_DEPENDS) $(HERE)/build-certifi.sh
+	$(RUN_BUILD) --docker-image $(DOCKER_IMAGE_BUILD) certifi
+
 $(OUTDIR)/expat-$(EXPAT_VERSION)-$(PACKAGE_SUFFIX).tar: $(PYTHON_DEP_DEPENDS) $(HERE)/build-expat.sh
 	$(RUN_BUILD) --docker-image $(DOCKER_IMAGE_BUILD) expat
 
@@ -251,6 +254,7 @@ PYTHON_DEPENDS_$(1) := \
     $$(if$$(NEED_AUTOCONF),$$(OUTDIR)/autoconf-$$(AUTOCONF_VERSION)-$$(PACKAGE_SUFFIX).tar) \
     $$(if $$(NEED_BDB),$$(OUTDIR)/bdb-$$(BDB_VERSION)-$$(PACKAGE_SUFFIX).tar) \
     $$(if $$(NEED_BZIP2),$$(OUTDIR)/bzip2-$$(BZIP2_VERSION)-$$(PACKAGE_SUFFIX).tar) \
+    $$(OUTDIR)/certifi-$$(CERTIFI_VERSION)-$$(PACKAGE_SUFFIX).tar \
     $$(if $$(NEED_EXPAT),$$(OUTDIR)/expat-$$(EXPAT_VERSION)-$$(PACKAGE_SUFFIX).tar) \
     $$(if $$(NEED_LIBEDIT),$$(OUTDIR)/libedit-$$(LIBEDIT_VERSION)-$$(PACKAGE_SUFFIX).tar) \
     $$(if $$(NEED_LIBFFI_3_3),$$(OUTDIR)/libffi-3.3-$$(LIBFFI_3.3_VERSION)-$$(PACKAGE_SUFFIX).tar) \

--- a/cpython-unix/build-certifi.sh
+++ b/cpython-unix/build-certifi.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -ex
+
+mkdir -p out/tools/deps/share/certifi
+unzip -p "certifi-${CERTIFI_VERSION}-py3-none-any.whl" certifi/cacert.pem \
+  > out/tools/deps/share/certifi/cacert.pem

--- a/cpython-unix/build-certifi.sh
+++ b/cpython-unix/build-certifi.sh
@@ -8,3 +8,6 @@ set -ex
 mkdir -p out/tools/deps/share/certifi
 unzip -p "certifi-${CERTIFI_VERSION}-py3-none-any.whl" certifi/cacert.pem \
   > out/tools/deps/share/certifi/cacert.pem
+unzip -p "certifi-${CERTIFI_VERSION}-py3-none-any.whl" \
+  "certifi-${CERTIFI_VERSION}.dist-info/licenses/LICENSE" \
+  > out/tools/deps/share/certifi/LICENSE

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -1361,6 +1361,11 @@ if [ -d "${TOOLS_PATH}/deps/usr/share/terminfo" ]; then
   cp -av "${TOOLS_PATH}/deps/usr/share/terminfo" "${ROOT}/out/python/install/share/"
 fi
 
+# Copy a fallback CA bundle. Python will prefer the host trust store when one
+# exists and use this only for minimal environments without root certificates.
+mkdir -p "${ROOT}/out/python/install/etc/ssl"
+cp -av "${TOOLS_PATH}/deps/share/certifi/cacert.pem" "${ROOT}/out/python/install/etc/ssl/cert.pem"
+
 # config.c defines _PyImport_Inittab and extern references to modules, which
 # downstream consumers may want to strip. We bundle config.c and config.c.in so
 # a custom one can be produced downstream.
@@ -1386,4 +1391,5 @@ find "${ROOT}/out/python/install/lib/pkgconfig" -name \*.pc -type f -exec \
     sed "${sed_args[@]}" 's|^prefix=/install|prefix=${pcfiledir}/../..|' {} +
 
 mkdir "${ROOT}/out/python/licenses"
+cp "${ROOT}/LICENSE" "${ROOT}/out/python/licenses/"
 cp "${ROOT}"/LICENSE.*.txt "${ROOT}/out/python/licenses/"

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -316,7 +316,9 @@ fi
 # RHEL 8 (supported until 2029) and below, including Fedora 33 and below, do not
 # ship an /etc/ssl/cert.pem or a hashed /etc/ssl/cert/ directory. Patch to look at
 # /etc/pki/tls/cert.pem instead, if that file exists and /etc/ssl/cert.pem does not.
-patch -p1 -i ${ROOT}/patch-cpython-redhat-cert-file.patch
+if [[ "${TARGET_TRIPLE}" =~ linux ]]; then
+    patch -p1 -i "${ROOT}/patch-cpython-redhat-cert-file.patch"
+fi
 
 # Cherry-pick an upstream change in Python 3.15 to build _asyncio as
 # static (which we do anyway in our own fashion) and more importantly to
@@ -1361,10 +1363,12 @@ if [ -d "${TOOLS_PATH}/deps/usr/share/terminfo" ]; then
   cp -av "${TOOLS_PATH}/deps/usr/share/terminfo" "${ROOT}/out/python/install/share/"
 fi
 
-# Copy a fallback CA bundle. Python will prefer the host trust store when one
-# exists and use this only for minimal environments without root certificates.
-mkdir -p "${ROOT}/out/python/install/etc/ssl"
-cp -av "${TOOLS_PATH}/deps/share/certifi/cacert.pem" "${ROOT}/out/python/install/etc/ssl/cert.pem"
+# Copy a Linux fallback CA bundle. Python will prefer the host trust store when
+# one exists and use this only for minimal environments without root certificates.
+if [[ "${TARGET_TRIPLE}" =~ linux ]]; then
+    mkdir -p "${ROOT}/out/python/install/etc/ssl"
+    cp -av "${TOOLS_PATH}/deps/share/certifi/cacert.pem" "${ROOT}/out/python/install/etc/ssl/cert.pem"
+fi
 
 # config.c defines _PyImport_Inittab and extern references to modules, which
 # downstream consumers may want to strip. We bundle config.c and config.c.in so
@@ -1391,5 +1395,7 @@ find "${ROOT}/out/python/install/lib/pkgconfig" -name \*.pc -type f -exec \
     sed "${sed_args[@]}" 's|^prefix=/install|prefix=${pcfiledir}/../..|' {} +
 
 mkdir "${ROOT}/out/python/licenses"
-cp "${ROOT}/LICENSE" "${ROOT}/out/python/licenses/"
+if [[ "${TARGET_TRIPLE}" =~ linux ]]; then
+    cp "${ROOT}/LICENSE" "${ROOT}/out/python/licenses/"
+fi
 cp "${ROOT}"/LICENSE.*.txt "${ROOT}/out/python/licenses/"

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -318,6 +318,9 @@ fi
 # /etc/pki/tls/cert.pem instead, if that file exists and /etc/ssl/cert.pem does not.
 if [[ "${TARGET_TRIPLE}" =~ linux ]]; then
     patch -p1 -i "${ROOT}/patch-cpython-redhat-cert-file.patch"
+
+    # Fall back to a bundled CA file when the host image has no trust store.
+    patch -p1 -i "${ROOT}/patch-cpython-standalone-ca-fallback.patch"
 fi
 
 # Cherry-pick an upstream change in Python 3.15 to build _asyncio as

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -1396,6 +1396,6 @@ find "${ROOT}/out/python/install/lib/pkgconfig" -name \*.pc -type f -exec \
 
 mkdir "${ROOT}/out/python/licenses"
 if [[ "${TARGET_TRIPLE}" =~ linux ]]; then
-    cp "${ROOT}/LICENSE" "${ROOT}/out/python/licenses/"
+    cp "${TOOLS_PATH}/deps/share/certifi/LICENSE" "${ROOT}/out/python/licenses/LICENSE.certifi.txt"
 fi
 cp "${ROOT}"/LICENSE.*.txt "${ROOT}/out/python/licenses/"

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -775,6 +775,7 @@ def build_cpython(
             python_archive,
             setuptools_archive,
             pip_archive,
+            ROOT / "LICENSE",
             SUPPORT / "build-cpython.sh",
             SUPPORT / "run_tests-13.py",
         ):
@@ -1135,6 +1136,7 @@ def main():
         elif action in (
             "bdb",
             "bzip2",
+            "certifi",
             "expat",
             "libffi-3.3",
             "libffi",

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -775,11 +775,13 @@ def build_cpython(
             python_archive,
             setuptools_archive,
             pip_archive,
-            ROOT / "LICENSE",
             SUPPORT / "build-cpython.sh",
             SUPPORT / "run_tests-13.py",
         ):
             build_env.copy_file(p)
+
+        if "-linux-" in target_triple:
+            build_env.copy_file(ROOT / "LICENSE")
 
         for f in sorted(os.listdir(ROOT)):
             if f.startswith("LICENSE.") and f.endswith(".txt"):

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -780,9 +780,6 @@ def build_cpython(
         ):
             build_env.copy_file(p)
 
-        if "-linux-" in target_triple:
-            build_env.copy_file(ROOT / "LICENSE")
-
         for f in sorted(os.listdir(ROOT)):
             if f.startswith("LICENSE.") and f.endswith(".txt"):
                 build_env.copy_file(ROOT / f)

--- a/cpython-unix/patch-cpython-redhat-cert-file.patch
+++ b/cpython-unix/patch-cpython-redhat-cert-file.patch
@@ -2,29 +2,49 @@ diff --git a/Lib/ssl.py b/Lib/ssl.py
 index 42ebb8ed384..c15c0ec940f 100644
 --- a/Lib/ssl.py
 +++ b/Lib/ssl.py
-@@ -423,6 +423,8 @@ class SSLContext(_SSLContext):
+@@ -423,6 +423,10 @@ class SSLContext(_SSLContext):
      """An SSLContext holds various SSL-related configuration options and
      data, such as certificates and possibly a private key."""
      _windows_cert_stores = ("CA", "ROOT")
 +    _FALLBACK_CERT_FILE = "/etc/pki/tls/cert.pem"  # RHEL 8 and below, Fedora 33 and below
 +    _FALLBACK_CERT_DIR = "/etc/pki/tls/certs"  # RHEL 8 and below, Fedora 33 and below
++    _STANDALONE_CERT_FALLBACK_ENV = "PYTHON_BUILD_STANDALONE_DISABLE_CA_FALLBACK"
++    _STANDALONE_CERT_FILE = os.path.join(sys.base_prefix, "etc", "ssl", "cert.pem")
  
      sslsocket_class = None  # SSLSocket is assigned later.
      sslobject_class = None  # SSLObject is assigned later.
-@@ -531,6 +533,16 @@ def load_default_certs(self, purpose=Purpose.SERVER_AUTH):
+@@ -531,6 +534,34 @@ def load_default_certs(self, purpose=Purpose.SERVER_AUTH):
          if sys.platform == "win32":
              for storename in self._windows_cert_stores:
                  self._load_windows_store_certs(storename, purpose)
-+        elif sys.platform == "linux":
++        else:
++            def _cert_dir_has_entries(path):
++                if not os.path.isdir(path):
++                    return False
++                try:
++                    return next(os.scandir(path), None) is not None
++                except OSError:
++                    return False
++
 +            _def_paths = _ssl.get_default_verify_paths()
-+            if (_def_paths[0] not in os.environ and
-+                not os.path.isfile(_def_paths[1]) and
-+                os.path.isfile(self._FALLBACK_CERT_FILE)):
-+                self.load_verify_locations(cafile=self._FALLBACK_CERT_FILE)
-+            if (_def_paths[2] not in os.environ and
-+                not os.path.isdir(_def_paths[3]) and
-+                os.path.isdir(self._FALLBACK_CERT_DIR)):
-+                self.load_verify_locations(capath=self._FALLBACK_CERT_DIR)
++            _has_cert_file = (
++                _def_paths[0] in os.environ or os.path.isfile(_def_paths[1])
++            )
++            _has_cert_dir = (
++                _def_paths[2] in os.environ or _cert_dir_has_entries(_def_paths[3])
++            )
++            if sys.platform == "linux":
++                if not _has_cert_file and os.path.isfile(self._FALLBACK_CERT_FILE):
++                    self.load_verify_locations(cafile=self._FALLBACK_CERT_FILE)
++                    _has_cert_file = True
++                if not _has_cert_dir and _cert_dir_has_entries(self._FALLBACK_CERT_DIR):
++                    self.load_verify_locations(capath=self._FALLBACK_CERT_DIR)
++                    _has_cert_dir = True
++            if (self._STANDALONE_CERT_FALLBACK_ENV not in os.environ and
++                not _has_cert_file and
++                not _has_cert_dir and
++                os.path.isfile(self._STANDALONE_CERT_FILE)):
++                self.load_verify_locations(cafile=self._STANDALONE_CERT_FILE)
          self.set_default_verify_paths()
  
      if hasattr(_SSLContext, 'minimum_version'):

--- a/cpython-unix/patch-cpython-redhat-cert-file.patch
+++ b/cpython-unix/patch-cpython-redhat-cert-file.patch
@@ -13,16 +13,24 @@ index 42ebb8ed384..c15c0ec940f 100644
  
      sslsocket_class = None  # SSLSocket is assigned later.
      sslobject_class = None  # SSLObject is assigned later.
-@@ -531,6 +534,34 @@ def load_default_certs(self, purpose=Purpose.SERVER_AUTH):
+@@ -531,6 +535,41 @@ def load_default_certs(self, purpose=Purpose.SERVER_AUTH):
          if sys.platform == "win32":
              for storename in self._windows_cert_stores:
                  self._load_windows_store_certs(storename, purpose)
-+        else:
-+            def _cert_dir_has_entries(path):
++        elif sys.platform == "linux":
++            def _has_hashed_certs(path):
 +                if not os.path.isdir(path):
 +                    return False
 +                try:
-+                    return next(os.scandir(path), None) is not None
++                    for entry in os.scandir(path):
++                        name, dot, suffix = entry.name.partition(".")
++                        if dot and len(name) == 8 and suffix.isdigit():
++                            try:
++                                int(name, 16)
++                            except ValueError:
++                                continue
++                            return True
++                    return False
 +                except OSError:
 +                    return False
 +
@@ -31,15 +39,14 @@ index 42ebb8ed384..c15c0ec940f 100644
 +                _def_paths[0] in os.environ or os.path.isfile(_def_paths[1])
 +            )
 +            _has_cert_dir = (
-+                _def_paths[2] in os.environ or _cert_dir_has_entries(_def_paths[3])
++                _def_paths[2] in os.environ or _has_hashed_certs(_def_paths[3])
 +            )
-+            if sys.platform == "linux":
-+                if not _has_cert_file and os.path.isfile(self._FALLBACK_CERT_FILE):
-+                    self.load_verify_locations(cafile=self._FALLBACK_CERT_FILE)
-+                    _has_cert_file = True
-+                if not _has_cert_dir and _cert_dir_has_entries(self._FALLBACK_CERT_DIR):
-+                    self.load_verify_locations(capath=self._FALLBACK_CERT_DIR)
-+                    _has_cert_dir = True
++            if not _has_cert_file and os.path.isfile(self._FALLBACK_CERT_FILE):
++                self.load_verify_locations(cafile=self._FALLBACK_CERT_FILE)
++                _has_cert_file = True
++            if not _has_cert_dir and _has_hashed_certs(self._FALLBACK_CERT_DIR):
++                self.load_verify_locations(capath=self._FALLBACK_CERT_DIR)
++                _has_cert_dir = True
 +            if (self._STANDALONE_CERT_FALLBACK_ENV not in os.environ and
 +                not _has_cert_file and
 +                not _has_cert_dir and

--- a/cpython-unix/patch-cpython-redhat-cert-file.patch
+++ b/cpython-unix/patch-cpython-redhat-cert-file.patch
@@ -2,56 +2,29 @@ diff --git a/Lib/ssl.py b/Lib/ssl.py
 index 42ebb8ed384..c15c0ec940f 100644
 --- a/Lib/ssl.py
 +++ b/Lib/ssl.py
-@@ -423,6 +423,10 @@ class SSLContext(_SSLContext):
+@@ -423,6 +423,8 @@ class SSLContext(_SSLContext):
      """An SSLContext holds various SSL-related configuration options and
      data, such as certificates and possibly a private key."""
      _windows_cert_stores = ("CA", "ROOT")
 +    _FALLBACK_CERT_FILE = "/etc/pki/tls/cert.pem"  # RHEL 8 and below, Fedora 33 and below
 +    _FALLBACK_CERT_DIR = "/etc/pki/tls/certs"  # RHEL 8 and below, Fedora 33 and below
-+    _STANDALONE_CERT_FALLBACK_ENV = "PYTHON_BUILD_STANDALONE_DISABLE_CA_FALLBACK"
-+    _STANDALONE_CERT_FILE = os.path.join(sys.base_prefix, "etc", "ssl", "cert.pem")
  
      sslsocket_class = None  # SSLSocket is assigned later.
      sslobject_class = None  # SSLObject is assigned later.
-@@ -531,6 +535,41 @@ def load_default_certs(self, purpose=Purpose.SERVER_AUTH):
+@@ -531,6 +533,16 @@ def load_default_certs(self, purpose=Purpose.SERVER_AUTH):
          if sys.platform == "win32":
              for storename in self._windows_cert_stores:
                  self._load_windows_store_certs(storename, purpose)
 +        elif sys.platform == "linux":
-+            def _has_hashed_certs(path):
-+                if not os.path.isdir(path):
-+                    return False
-+                try:
-+                    for entry in os.scandir(path):
-+                        name, dot, suffix = entry.name.partition(".")
-+                        if dot and len(name) == 8 and suffix.isdigit():
-+                            try:
-+                                int(name, 16)
-+                            except ValueError:
-+                                continue
-+                            return True
-+                    return False
-+                except OSError:
-+                    return False
-+
 +            _def_paths = _ssl.get_default_verify_paths()
-+            _has_cert_file = (
-+                _def_paths[0] in os.environ or os.path.isfile(_def_paths[1])
-+            )
-+            _has_cert_dir = (
-+                _def_paths[2] in os.environ or _has_hashed_certs(_def_paths[3])
-+            )
-+            if not _has_cert_file and os.path.isfile(self._FALLBACK_CERT_FILE):
++            if (_def_paths[0] not in os.environ and
++                not os.path.isfile(_def_paths[1]) and
++                os.path.isfile(self._FALLBACK_CERT_FILE)):
 +                self.load_verify_locations(cafile=self._FALLBACK_CERT_FILE)
-+                _has_cert_file = True
-+            if not _has_cert_dir and _has_hashed_certs(self._FALLBACK_CERT_DIR):
++            if (_def_paths[2] not in os.environ and
++                not os.path.isdir(_def_paths[3]) and
++                os.path.isdir(self._FALLBACK_CERT_DIR)):
 +                self.load_verify_locations(capath=self._FALLBACK_CERT_DIR)
-+                _has_cert_dir = True
-+            if (self._STANDALONE_CERT_FALLBACK_ENV not in os.environ and
-+                not _has_cert_file and
-+                not _has_cert_dir and
-+                os.path.isfile(self._STANDALONE_CERT_FILE)):
-+                self.load_verify_locations(cafile=self._STANDALONE_CERT_FILE)
          self.set_default_verify_paths()
  
      if hasattr(_SSLContext, 'minimum_version'):

--- a/cpython-unix/patch-cpython-standalone-ca-fallback.patch
+++ b/cpython-unix/patch-cpython-standalone-ca-fallback.patch
@@ -1,0 +1,42 @@
+diff --git a/Lib/ssl.py b/Lib/ssl.py
+--- a/Lib/ssl.py
++++ b/Lib/ssl.py
+@@ -425,6 +425,8 @@ class SSLContext(_SSLContext):
+     _windows_cert_stores = ("CA", "ROOT")
+     _FALLBACK_CERT_FILE = "/etc/pki/tls/cert.pem"  # RHEL 8 and below, Fedora 33 and below
+     _FALLBACK_CERT_DIR = "/etc/pki/tls/certs"  # RHEL 8 and below, Fedora 33 and below
++    _STANDALONE_CERT_FALLBACK_ENV = "PYTHON_BUILD_STANDALONE_DISABLE_CA_FALLBACK"
++    _STANDALONE_CERT_FILE = os.path.join(sys.base_prefix, "etc", "ssl", "cert.pem")
+ 
+     sslsocket_class = None  # SSLSocket is assigned later.
+     sslobject_class = None  # SSLObject is assigned later.
+@@ -535,14 +537,23 @@ def load_default_certs(self, purpose=Purpose.SERVER_AUTH):
+                 self._load_windows_store_certs(storename, purpose)
+         elif sys.platform == "linux":
+             _def_paths = _ssl.get_default_verify_paths()
+-            if (_def_paths[0] not in os.environ and
+-                not os.path.isfile(_def_paths[1]) and
+-                os.path.isfile(self._FALLBACK_CERT_FILE)):
++            _has_cert_file = (
++                _def_paths[0] in os.environ or os.path.isfile(_def_paths[1])
++            )
++            _has_cert_dir = (
++                _def_paths[2] in os.environ or os.path.isdir(_def_paths[3])
++            )
++            if not _has_cert_file and os.path.isfile(self._FALLBACK_CERT_FILE):
+                 self.load_verify_locations(cafile=self._FALLBACK_CERT_FILE)
+-            if (_def_paths[2] not in os.environ and
+-                not os.path.isdir(_def_paths[3]) and
+-                os.path.isdir(self._FALLBACK_CERT_DIR)):
++                _has_cert_file = True
++            if not _has_cert_dir and os.path.isdir(self._FALLBACK_CERT_DIR):
+                 self.load_verify_locations(capath=self._FALLBACK_CERT_DIR)
++                _has_cert_dir = True
++            if (self._STANDALONE_CERT_FALLBACK_ENV not in os.environ and
++                not _has_cert_file and
++                not _has_cert_dir and
++                os.path.isfile(self._STANDALONE_CERT_FILE)):
++                self.load_verify_locations(cafile=self._STANDALONE_CERT_FILE)
+         self.set_default_verify_paths()
+ 
+     if hasattr(_SSLContext, 'minimum_version'):

--- a/docs/quirks.rst
+++ b/docs/quirks.rst
@@ -69,6 +69,24 @@ at build time! So actually using this bundled terminfo database will
 require custom code setting ``TERMINFO_DIRS`` before
 ncurses/libedit/readline are loaded.
 
+.. _quirk_fallback_ca_bundle:
+
+Fallback CA Certificate Bundle
+==============================
+
+On Unix platforms, Python prefers the trust store provided by the host
+operating system. When none of the usual host certificate locations exist,
+these distributions fall back to a bundled CA certificate file at
+``etc/ssl/cert.pem`` inside the Python installation.
+
+The bundled file is a safety net for minimal environments such as scratch-like
+container images. If your image has an operating-system trust store, that store
+continues to take precedence so distribution-specific roots and locally added
+enterprise roots still behave as expected.
+
+To opt out of the bundled fallback entirely, set
+``PYTHON_BUILD_STANDALONE_DISABLE_CA_FALLBACK=1`` in the runtime environment.
+
 .. _quirk_macos_no_tix:
 
 No tix on UNIX

--- a/docs/quirks.rst
+++ b/docs/quirks.rst
@@ -74,9 +74,9 @@ ncurses/libedit/readline are loaded.
 Fallback CA Certificate Bundle
 ==============================
 
-On Unix platforms, Python prefers the trust store provided by the host
-operating system. When none of the usual host certificate locations exist,
-these distributions fall back to a bundled CA certificate file at
+On Linux, Python prefers the trust store provided by the host operating
+system. When none of the usual host certificate locations exist, these
+distributions fall back to a bundled CA certificate file at
 ``etc/ssl/cert.pem`` inside the Python installation.
 
 The bundled file is a safety net for minimal environments such as scratch-like

--- a/pythonbuild/disttests/__init__.py
+++ b/pythonbuild/disttests/__init__.py
@@ -217,6 +217,14 @@ class TestPythonInterpreter(unittest.TestCase):
 
         ssl.create_default_context()
 
+        if os.name != "nt":
+            bundled_ca_file = os.path.join(INSTALL_ROOT, "etc", "ssl", "cert.pem")
+            self.assertTrue(os.path.isfile(bundled_ca_file))
+
+            bundled_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            bundled_context.load_verify_locations(cafile=bundled_ca_file)
+            self.assertGreater(bundled_context.cert_store_stats()["x509_ca"], 0)
+
     @unittest.skipIf(
         sys.version_info[:2] < (3, 13),
         "Free-threaded builds are only available in 3.13+",

--- a/pythonbuild/disttests/__init__.py
+++ b/pythonbuild/disttests/__init__.py
@@ -217,13 +217,16 @@ class TestPythonInterpreter(unittest.TestCase):
 
         ssl.create_default_context()
 
-        if sys.platform == "linux":
-            bundled_ca_file = os.path.join(INSTALL_ROOT, "etc", "ssl", "cert.pem")
-            self.assertTrue(os.path.isfile(bundled_ca_file))
+    @unittest.skipUnless(sys.platform == "linux", "Linux-specific CA fallback")
+    def test_ssl_ca_fallback_bundle_is_packaged(self):
+        import ssl
 
-            bundled_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            bundled_context.load_verify_locations(cafile=bundled_ca_file)
-            self.assertGreater(bundled_context.cert_store_stats()["x509_ca"], 0)
+        bundled_ca_file = os.path.join(INSTALL_ROOT, "etc", "ssl", "cert.pem")
+        self.assertTrue(os.path.isfile(bundled_ca_file))
+
+        bundled_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        bundled_context.load_verify_locations(cafile=bundled_ca_file)
+        self.assertGreater(bundled_context.cert_store_stats()["x509_ca"], 0)
 
     @unittest.skipIf(
         sys.version_info[:2] < (3, 13),

--- a/pythonbuild/disttests/__init__.py
+++ b/pythonbuild/disttests/__init__.py
@@ -217,7 +217,7 @@ class TestPythonInterpreter(unittest.TestCase):
 
         ssl.create_default_context()
 
-        if os.name != "nt":
+        if sys.platform == "linux":
             bundled_ca_file = os.path.join(INSTALL_ROOT, "etc", "ssl", "cert.pem")
             self.assertTrue(os.path.isfile(bundled_ca_file))
 

--- a/pythonbuild/downloads.py
+++ b/pythonbuild/downloads.py
@@ -47,6 +47,14 @@ DOWNLOADS = {
         "licenses": ["bzip2-1.0.6"],
         "license_file": "LICENSE.bzip2.txt",
     },
+    "certifi": {
+        "url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
+        "size": 135707,
+        "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
+        "version": "2026.4.22",
+        "licenses": ["MPL-2.0"],
+        "license_file": "LICENSE",
+    },
     "cpython-3.10": {
         "url": "https://www.python.org/ftp/python/3.10.20/Python-3.10.20.tar.xz",
         "size": 19868028,

--- a/pythonbuild/downloads.py
+++ b/pythonbuild/downloads.py
@@ -53,7 +53,7 @@ DOWNLOADS = {
         "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
         "version": "2026.4.22",
         "licenses": ["MPL-2.0"],
-        "license_file": "LICENSE",
+        "license_file": "LICENSE.certifi.txt",
     },
     "cpython-3.10": {
         "url": "https://www.python.org/ftp/python/3.10.20/Python-3.10.20.tar.xz",

--- a/pythonbuild/utils.py
+++ b/pythonbuild/utils.py
@@ -100,11 +100,22 @@ def target_needs(yaml_path: pathlib.Path, target: str):
     settings = get_targets(yaml_path)[target]
 
     needs = set(settings["needs"])
-    # Every Unix distribution ships a fallback CA bundle.
-    needs.add("certifi")
+    # Linux distributions ship a fallback CA bundle for minimal images.
+    if "-linux-" in target:
+        needs.add("certifi")
 
     # Ship libedit linked readline extension to avoid a GPL dependency.
     needs.discard("readline")
+
+    return needs
+
+
+def target_makefile_needs(target: str, settings: dict) -> set[str]:
+    """Obtain dependency names that should be emitted into target Makefiles."""
+    needs = set(settings.get("needs", []))
+
+    if "-linux-" in target:
+        needs.add("certifi")
 
     return needs
 
@@ -192,7 +203,7 @@ def write_triples_makefiles(
             makefile_path = dest_dir / ("Makefile.%s.%s" % (host_platform, triple))
 
             lines = []
-            for need in settings.get("needs", []):
+            for need in sorted(target_makefile_needs(triple, settings)):
                 lines.append(
                     "NEED_%s := 1\n" % need.upper().replace("-", "_").replace(".", "_")
                 )

--- a/pythonbuild/utils.py
+++ b/pythonbuild/utils.py
@@ -100,6 +100,8 @@ def target_needs(yaml_path: pathlib.Path, target: str):
     settings = get_targets(yaml_path)[target]
 
     needs = set(settings["needs"])
+    # Every Unix distribution ships a fallback CA bundle.
+    needs.add("certifi")
 
     # Ship libedit linked readline extension to avoid a GPL dependency.
     needs.discard("readline")

--- a/pythonbuild/utils.py
+++ b/pythonbuild/utils.py
@@ -110,12 +110,12 @@ def target_needs(yaml_path: pathlib.Path, target: str):
     return needs
 
 
-def target_makefile_needs(target: str, settings: dict) -> set[str]:
+def target_makefile_needs(target: str, settings: dict) -> list[str]:
     """Obtain dependency names that should be emitted into target Makefiles."""
-    needs = set(settings.get("needs", []))
+    needs = list(settings.get("needs", []))
 
-    if "-linux-" in target:
-        needs.add("certifi")
+    if "-linux-" in target and "certifi" not in needs:
+        needs.append("certifi")
 
     return needs
 
@@ -203,7 +203,7 @@ def write_triples_makefiles(
             makefile_path = dest_dir / ("Makefile.%s.%s" % (host_platform, triple))
 
             lines = []
-            for need in sorted(target_makefile_needs(triple, settings)):
+            for need in target_makefile_needs(triple, settings):
                 lines.append(
                     "NEED_%s := 1\n" % need.upper().replace("-", "_").replace(".", "_")
                 )

--- a/pythonbuild/utils.py
+++ b/pythonbuild/utils.py
@@ -99,10 +99,7 @@ def target_needs(yaml_path: pathlib.Path, target: str):
     """Obtain the dependencies needed to build the specified target."""
     settings = get_targets(yaml_path)[target]
 
-    needs = set(settings["needs"])
-    # Linux distributions ship a fallback CA bundle for minimal images.
-    if "-linux-" in target:
-        needs.add("certifi")
+    needs = set(target_makefile_needs(target, settings))
 
     # Ship libedit linked readline extension to avoid a GPL dependency.
     needs.discard("readline")
@@ -114,6 +111,7 @@ def target_makefile_needs(target: str, settings: dict) -> list[str]:
     """Obtain dependency names that should be emitted into target Makefiles."""
     needs = list(settings.get("needs", []))
 
+    # Linux distributions ship a fallback CA bundle for minimal images.
     if "-linux-" in target and "certifi" not in needs:
         needs.append("certifi")
 


### PR DESCRIPTION
this is a common foot-gun when trying to build minimal images using python build standalone.

rather than relying on the user 1) ensuring root certificates are added to the final image AND 2) those certificates are placed in the correc place: bundle the Mozilla curated list from certifi.

for users who _definitely_ do not want any root certificates added, provide an opt-out via PYTHON_BUILD_STANDALONE_DISABLE_CA_FALLBACK