### PR TITLE
include missing vm_sockets.h for socket.AF_VSOCK

### DIFF
--- a/cpython-unix/build.Dockerfile
+++ b/cpython-unix/build.Dockerfile
@@ -7,12 +7,14 @@
 # Compression packages are needed to extract archives.
 #
 # Various other build tools are needed for various building.
+# Note linux-headers is installed to source a missing UAPI header, see below
 RUN ulimit -n 10000 && apt-get install \
     bzip2 \
     ca-certificates \
     curl \
     file \
     libc6-dev \
+    linux-headers-3.16.0-6-common \
     libffi-dev \
     make \
     patch \
@@ -23,3 +25,8 @@ RUN ulimit -n 10000 && apt-get install \
     unzip \
     zip \
     zlib1g-dev
+
+# Debian Jessie's linux-libc-dev is missing the vm_sockets header due to a typo
+# see https://lists.openwall.net/netdev/2014/12/01/2
+RUN install -m 0644 /usr/src/linux-headers-3.16.0-6-common/include/uapi/linux/vm_sockets.h \
+    /usr/include/linux/vm_sockets.h

--- a/pythonbuild/disttests/__init__.py
+++ b/pythonbuild/disttests/__init__.py
@@ -320,6 +320,13 @@ class TestPythonInterpreter(unittest.TestCase):
         with self.subTest(msg="weird argv[0]"):
             assertPythonWorks(sys.executable, argv0="/dev/null")
 
+    @unittest.skipUnless(sys.platform == "linux", "Linux-specific socket constant")
+    def test_socket_af_vsock(self):
+        import socket
+
+        self.assertTrue(hasattr(socket, "AF_VSOCK"))
+        self.assertEqual(socket.AF_VSOCK, 40)
+
     @unittest.skipUnless(sys.platform == "linux", "Linux-specific prctl")
     @unittest.skipIf(
         "static" in os.environ["BUILD_OPTIONS"],

--- a/pythonbuild/disttests/__init__.py
+++ b/pythonbuild/disttests/__init__.py
@@ -321,6 +321,11 @@ class TestPythonInterpreter(unittest.TestCase):
             assertPythonWorks(sys.executable, argv0="/dev/null")
 
     @unittest.skipUnless(sys.platform == "linux", "Linux-specific socket constant")
+    # TODO(jjh) remove when musl builds use a sysroot
+    @unittest.skipIf(
+        os.environ["TARGET_TRIPLE"].endswith("-musl"),
+        "kernel headers not available in musl",
+    )
     def test_socket_af_vsock(self):
         import socket
 


### PR DESCRIPTION
Include vm_sockets.h which is missing from the kernel UAPI headers in version 3.16 of the kernel. This file is missing due to a typo in the Kbuild file. The file is needed for CPython to make socket.AF_VSOCK available.

closes #1050