### PR TITLE
Cherry-pick an improved DER parser in _ssl.c from 3.12 onto 3.10 and 3.11

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -714,6 +714,14 @@ elif [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_11}" ]; then
     patch -p1 -i "${ROOT}/patch-getpath-use-base_executable-for-executable_dir.patch"
 fi
 
+# Cherry-pick python/cpython#100373 from 3.12 onto 3.10/3.11 to fix DER parsing with OpenSSL 3.5.7.
+# The old implementation does heuristics on the error codes returned from the ASN.1 parser, which
+# have changed slightly in openssl/openssl#30986 (commit 738688d762 in 3.5.7). The new
+# implementation does a better job of parsing and avoids the heuristics in the first place.
+if [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_11}" ]; then
+    patch -p1 -i "${ROOT}/patch-python-der-eof-parsing.patch"
+fi
+
 # We patched configure.ac above. Reflect those changes.
 autoconf
 

--- a/cpython-unix/patch-python-der-eof-parsing.patch
+++ b/cpython-unix/patch-python-der-eof-parsing.patch
@@ -1,0 +1,77 @@
+From acfe02f3b05436658d92add6b168538b30f357f0 Mon Sep 17 00:00:00 2001
+From: David Benjamin <davidben@google.com>
+Date: Fri, 24 Mar 2023 09:04:30 -0400
+Subject: [PATCH 1/1] gh-100372: Use BIO_eof to detect EOF for
+ SSL_FILETYPE_ASN1 (GH-100373)
+
+In PEM, we need to parse until error and then suppress `PEM_R_NO_START_LINE`, because PEM allows arbitrary leading and trailing data. DER, however, does not. Parsing until error and suppressing `ASN1_R_HEADER_TOO_LONG` doesn't quite work because that error also covers some cases that should be rejected.
+
+Instead, check `BIO_eof` early and stop the loop that way.
+
+Automerge-Triggered-By: GH:Yhg1s
+---
+ Lib/test/test_ssl.py                                   |  2 ++
+ .../2022-12-20-10-55-14.gh-issue-100372.utfP65.rst     |  2 ++
+ Modules/_ssl.c                                         | 10 ++++++----
+ 3 files changed, 10 insertions(+), 4 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Library/2022-12-20-10-55-14.gh-issue-100372.utfP65.rst
+
+diff --git a/Lib/test/test_ssl.py b/Lib/test/test_ssl.py
+index 1317efb33c2..abf024fb89d 100644
+--- a/Lib/test/test_ssl.py
++++ b/Lib/test/test_ssl.py
+@@ -1289,6 +1289,8 @@ def test_load_verify_cadata(self):
+             "not enough data: cadata does not contain a certificate"
+         ):
+             ctx.load_verify_locations(cadata=b"broken")
++        with self.assertRaises(ssl.SSLError):
++            ctx.load_verify_locations(cadata=cacert_der + b"A")
+ 
+     @unittest.skipIf(Py_DEBUG_WIN32, "Avoid mixing debug/release CRT on Windows")
+     def test_load_dh_params(self):
+diff --git a/Misc/NEWS.d/next/Library/2022-12-20-10-55-14.gh-issue-100372.utfP65.rst b/Misc/NEWS.d/next/Library/2022-12-20-10-55-14.gh-issue-100372.utfP65.rst
+new file mode 100644
+index 00000000000..ec37aff5092
+--- /dev/null
++++ b/Misc/NEWS.d/next/Library/2022-12-20-10-55-14.gh-issue-100372.utfP65.rst
+@@ -0,0 +1,2 @@
++:meth:`ssl.SSLContext.load_verify_locations` no longer incorrectly accepts
++some cases of trailing data when parsing DER.
+diff --git a/Modules/_ssl.c b/Modules/_ssl.c
+index 36b66cdb531..3fbb37332f6 100644
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -3930,7 +3930,7 @@ _add_ca_certs(PySSLContext *self, const void *data, Py_ssize_t len,
+ {
+     BIO *biobuf = NULL;
+     X509_STORE *store;
+-    int retval = -1, err, loaded = 0;
++    int retval = -1, err, loaded = 0, was_bio_eof = 0;
+ 
+     assert(filetype == SSL_FILETYPE_ASN1 || filetype == SSL_FILETYPE_PEM);
+ 
+@@ -3958,6 +3958,10 @@ _add_ca_certs(PySSLContext *self, const void *data, Py_ssize_t len,
+         int r;
+ 
+         if (filetype == SSL_FILETYPE_ASN1) {
++            if (BIO_eof(biobuf)) {
++                was_bio_eof = 1;
++                break;
++            }
+             cert = d2i_X509_bio(biobuf, NULL);
+         } else {
+             cert = PEM_read_bio_X509(biobuf, NULL,
+@@ -3993,9 +3997,7 @@ _add_ca_certs(PySSLContext *self, const void *data, Py_ssize_t len,
+         }
+         _setSSLError(get_state_ctx(self), msg, 0, __FILE__, __LINE__);
+         retval = -1;
+-    } else if ((filetype == SSL_FILETYPE_ASN1) &&
+-                    (ERR_GET_LIB(err) == ERR_LIB_ASN1) &&
+-                    (ERR_GET_REASON(err) == ASN1_R_HEADER_TOO_LONG)) {
++    } else if ((filetype == SSL_FILETYPE_ASN1) && was_bio_eof) {
+         /* EOF ASN1 file, not an error */
+         ERR_clear_error();
+         retval = 0;
+-- 
+2.50.1 (Apple Git-155)
+

--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -311,6 +311,30 @@ def static_replace_in_file(p: pathlib.Path, search, replace):
         fh.write(data)
 
 
+def apply_source_patch(cpython_source_path: pathlib.Path, patch_path: pathlib.Path):
+    with patch_path.open("rb") as fh:
+        patch = fh.read().replace(b"\r\n", b"\n")
+
+    with tempfile.NamedTemporaryFile("wb", delete=False) as fh:
+        fh.write(patch)
+        normalized_patch = pathlib.Path(fh.name)
+
+    try:
+        subprocess.run(
+            [
+                "git.exe",
+                "-C",
+                str(cpython_source_path),
+                "apply",
+                "--whitespace=nowarn",
+                str(normalized_patch),
+            ],
+            check=True,
+        )
+    finally:
+        normalized_patch.unlink()
+
+
 OPENSSL_PROPS_REMOVE_RULES_LEGACY = b"""
   <ItemGroup>
     <_SSLDLL Include="$(opensslOutDir)\libcrypto$(_DLLSuffix).dll" />
@@ -1502,6 +1526,18 @@ def build_cpython(
 
         cpython_source_path = td / ("Python-%s" % python_version)
         pcbuild_path = cpython_source_path / "PCbuild"
+
+        # Cherry-pick python/cpython#100373 from 3.12 onto 3.10/3.11 to fix DER
+        # parsing with OpenSSL 3.5.7.  The old implementation does heuristics
+        # on the error codes returned from the ASN.1 parser, which have changed
+        # slightly in openssl/openssl#30986 (commit 738688d762 in 3.5.7). The
+        # new implementation does a better job of parsing and avoids the
+        # heuristics in the first place.
+        if meets_python_maximum_version(python_version, "3.11"):
+            apply_source_patch(
+                cpython_source_path,
+                SUPPORT / "patch-python-der-eof-parsing.patch",
+            )
 
         out_dir = td / "out"
 

--- a/cpython-windows/patch-python-der-eof-parsing.patch
+++ b/cpython-windows/patch-python-der-eof-parsing.patch
@@ -1,0 +1,77 @@
+From acfe02f3b05436658d92add6b168538b30f357f0 Mon Sep 17 00:00:00 2001
+From: David Benjamin <davidben@google.com>
+Date: Fri, 24 Mar 2023 09:04:30 -0400
+Subject: [PATCH 1/1] gh-100372: Use BIO_eof to detect EOF for
+ SSL_FILETYPE_ASN1 (GH-100373)
+
+In PEM, we need to parse until error and then suppress `PEM_R_NO_START_LINE`, because PEM allows arbitrary leading and trailing data. DER, however, does not. Parsing until error and suppressing `ASN1_R_HEADER_TOO_LONG` doesn't quite work because that error also covers some cases that should be rejected.
+
+Instead, check `BIO_eof` early and stop the loop that way.
+
+Automerge-Triggered-By: GH:Yhg1s
+---
+ Lib/test/test_ssl.py                                   |  2 ++
+ .../2022-12-20-10-55-14.gh-issue-100372.utfP65.rst     |  2 ++
+ Modules/_ssl.c                                         | 10 ++++++----
+ 3 files changed, 10 insertions(+), 4 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Library/2022-12-20-10-55-14.gh-issue-100372.utfP65.rst
+
+diff --git a/Lib/test/test_ssl.py b/Lib/test/test_ssl.py
+index 1317efb33c2..abf024fb89d 100644
+--- a/Lib/test/test_ssl.py
++++ b/Lib/test/test_ssl.py
+@@ -1289,6 +1289,8 @@ def test_load_verify_cadata(self):
+             "not enough data: cadata does not contain a certificate"
+         ):
+             ctx.load_verify_locations(cadata=b"broken")
++        with self.assertRaises(ssl.SSLError):
++            ctx.load_verify_locations(cadata=cacert_der + b"A")
+ 
+     @unittest.skipIf(Py_DEBUG_WIN32, "Avoid mixing debug/release CRT on Windows")
+     def test_load_dh_params(self):
+diff --git a/Misc/NEWS.d/next/Library/2022-12-20-10-55-14.gh-issue-100372.utfP65.rst b/Misc/NEWS.d/next/Library/2022-12-20-10-55-14.gh-issue-100372.utfP65.rst
+new file mode 100644
+index 00000000000..ec37aff5092
+--- /dev/null
++++ b/Misc/NEWS.d/next/Library/2022-12-20-10-55-14.gh-issue-100372.utfP65.rst
+@@ -0,0 +1,2 @@
++:meth:`ssl.SSLContext.load_verify_locations` no longer incorrectly accepts
++some cases of trailing data when parsing DER.
+diff --git a/Modules/_ssl.c b/Modules/_ssl.c
+index 36b66cdb531..3fbb37332f6 100644
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -3930,7 +3930,7 @@ _add_ca_certs(PySSLContext *self, const void *data, Py_ssize_t len,
+ {
+     BIO *biobuf = NULL;
+     X509_STORE *store;
+-    int retval = -1, err, loaded = 0;
++    int retval = -1, err, loaded = 0, was_bio_eof = 0;
+ 
+     assert(filetype == SSL_FILETYPE_ASN1 || filetype == SSL_FILETYPE_PEM);
+ 
+@@ -3958,6 +3958,10 @@ _add_ca_certs(PySSLContext *self, const void *data, Py_ssize_t len,
+         int r;
+ 
+         if (filetype == SSL_FILETYPE_ASN1) {
++            if (BIO_eof(biobuf)) {
++                was_bio_eof = 1;
++                break;
++            }
+             cert = d2i_X509_bio(biobuf, NULL);
+         } else {
+             cert = PEM_read_bio_X509(biobuf, NULL,
+@@ -3993,9 +3997,7 @@ _add_ca_certs(PySSLContext *self, const void *data, Py_ssize_t len,
+         }
+         _setSSLError(get_state_ctx(self), msg, 0, __FILE__, __LINE__);
+         retval = -1;
+-    } else if ((filetype == SSL_FILETYPE_ASN1) &&
+-                    (ERR_GET_LIB(err) == ERR_LIB_ASN1) &&
+-                    (ERR_GET_REASON(err) == ASN1_R_HEADER_TOO_LONG)) {
++    } else if ((filetype == SSL_FILETYPE_ASN1) && was_bio_eof) {
+         /* EOF ASN1 file, not an error */
+         ERR_clear_error();
+         retval = 0;
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
This fixes the inability to load DER correctly with OpenSSL 3.5.7.