### PR TITLE
riscv: Use newer binutils ld to address linker relaxation issues

### DIFF
--- a/cpython-unix/build.cross-riscv64.Dockerfile
+++ b/cpython-unix/build.cross-riscv64.Dockerfile
@@ -17,7 +17,7 @@ ENV HOME=/build \
 CMD ["/bin/bash", "--login"]
 WORKDIR '/build'
 
-RUN for s in debian_buster debian_buster-updates debian-security_buster/updates; do \
+RUN for s in debian_buster debian_buster-updates debian-security_buster/updates debian_bullseye; do \
       echo "deb http://snapshot.debian.org/archive/${s%_*}/20250109T084424Z/ ${s#*_} main"; \
     done > /etc/apt/sources.list && \
     ( echo 'quiet "true";'; \
@@ -26,6 +26,8 @@ RUN for s in debian_buster debian_buster-updates debian-security_buster/updates;
       echo 'Acquire::Check-Valid-Until "false";'; \
       echo 'Acquire::Retries "5";'; \
     ) > /etc/apt/apt.conf.d/99cpython-portable
+
+RUN ( echo 'Package: *'; echo 'Pin: release n=bullseye'; echo 'Pin-Priority: -1' ) > /etc/apt/preferences.d/99cpython-portable
 
 RUN apt-get update
 
@@ -49,7 +51,7 @@ RUN apt-get install \
 
 # riscv64 sysroot and host binutils for the riscv64-linux-gnu target
 RUN apt-get install \
-    binutils-riscv64-linux-gnu \
+    binutils-riscv64-linux-gnu/bullseye \
     libc6-riscv64-cross \
     libc6-dev-riscv64-cross \
     linux-libc-dev-riscv64-cross \


### PR DESCRIPTION
In the riscv Docker container, install binutils-riscv64-linux-gnu (only) from Debian 11 "bullseye" instead of Debian 10 "buster" to get ld 2.35 instead of 2.31. This is intended to address

    /tools/deps/lib/libcrypto.a(libcommon-lib-ciphercommon.o): in function `.L0 ': ciphercommon.c:(.text+0x1534): relocation truncated to fit: R_RISCV_JAL against symbol `ERR_set_error' defined in .text section in /tools/deps/lib/libcrypto.a(libcrypto-lib-err_blocks.o)

which started showing up after the OpenSSL 3.5.7 upgrade. The error message indicates that the linker is failing to be able to fill in a relocation for a `jal` instruction, which does a PC-relative jump with a limit of +-1 MB, presumably because the relevant binary sizes got a little bigger. There are other call sequences that can handle farther calls. The need to fill in R_RISCV_JAL here is a symptom of premature/incorrect "linker relaxation," see e.g.:

https://maskray.me/blog/2021-03-14-the-dark-side-of-riscv-linker-relaxation

Claude Fable 5 tells me: "Yes — binutils 2.31 is very likely your problem, and upgrading it is the first thing I'd try.The relaxation correctness fixes for exactly this failure mode postdate 2.31 (released mid-2018). PR 25181, where R_RISCV_CALL is wrongly relaxed to R_RISCV_JAL because R_RISCV_ALIGN relocations later adjust the target address, was reported and fixed in November 2019, and the closely related PR 25205 (JAL truncation against pthread_once in large static-ish links) was worked on in the same timeframe — both land in binutils 2.34. RISC-V relaxation in general got a lot of correctness work through the 2.32–2.35 series; 2.31-era RISC-V support is genuinely early. Any newer Debian works: bullseye ships 2.35.2, bookworm 2.40, both well past the fixes."