### PR TITLE
Revert "cross compile riscv64 with LLVM toolchain and sysroot (#1116)"

### DIFF
--- a/cpython-unix/build.cross-riscv64.Dockerfile
+++ b/cpython-unix/build.cross-riscv64.Dockerfile
@@ -29,12 +29,11 @@ RUN for s in debian_buster debian_buster-updates debian-security_buster/updates;
 
 RUN apt-get update
 
-# Build tools, same as in build.Dockerfile
+# Host building.
 RUN apt-get install \
     bzip2 \
-    ca-certificates \
-    curl \
-    file \
+    gcc \
+    g++ \
     libc6-dev \
     libffi-dev \
     make \
@@ -47,15 +46,32 @@ RUN apt-get install \
     zip \
     zlib1g-dev
 
-# riscv64 sysroot and host binutils for the riscv64-linux-gnu target
+# Cross-building.
 RUN apt-get install \
-    binutils-riscv64-linux-gnu \
-    libc6-riscv64-cross \
+    g++-aarch64-linux-gnu \
+    g++-arm-linux-gnueabi \
+    g++-arm-linux-gnueabihf \
+    g++-mips-linux-gnu \
+    g++-mips64el-linux-gnuabi64 \
+    g++-mipsel-linux-gnu \
+    g++-powerpc64le-linux-gnu \
+    g++-riscv64-linux-gnu \
+    g++-s390x-linux-gnu \
+    gcc-aarch64-linux-gnu \
+    gcc-arm-linux-gnueabi \
+    gcc-arm-linux-gnueabihf \
+    gcc-mips-linux-gnu \
+    gcc-mips64el-linux-gnuabi64 \
+    gcc-mipsel-linux-gnu \
+    gcc-powerpc64le-linux-gnu \
+    gcc-riscv64-linux-gnu \
+    gcc-s390x-linux-gnu \
+    libc6-dev-arm64-cross \
+    libc6-dev-armel-cross \
+    libc6-dev-armhf-cross \
+    libc6-dev-mips-cross \
+    libc6-dev-mips64el-cross \
+    libc6-dev-mipsel-cross \
+    libc6-dev-ppc64el-cross \
     libc6-dev-riscv64-cross \
-    linux-libc-dev-riscv64-cross \
-    libgcc1-riscv64-cross \
-    libgcc-8-dev-riscv64-cross
-
-# target specific symlinks to cross-compile using external LLVM toolchain
-RUN ln -s /tools/llvm/bin/clang /usr/bin/riscv64-linux-gnu-clang && \
-    ln -s /tools/llvm/bin/clang++ /usr/bin/riscv64-linux-gnu-clang++
+    libc6-dev-s390x-cross

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -445,12 +445,11 @@ riscv64-unknown-linux-gnu:
     - '3.13'
     - '3.14'
     - '3.15'
-  needs_toolchain: true
   docker_image_suffix: .cross-riscv64
-  host_cc: clang
-  host_cxx: clang++
-  target_cc: /usr/bin/riscv64-linux-gnu-clang
-  target_cxx: /usr/bin/riscv64-linux-gnu-clang++
+  host_cc: /usr/bin/x86_64-linux-gnu-gcc
+  host_cxx: /usr/bin/x86_64-linux-gnu-g++
+  target_cc: /usr/bin/riscv64-linux-gnu-gcc
+  target_cxx: /usr/bin/riscv64-linux-gnu-g++
   target_ldflags:
     # Hardening
     - '-Wl,-z,noexecstack'


### PR DESCRIPTION
This reverts commit 96a589a4042eaa37acb695cd70bd4ac925803994.

Having a split LLVM / older GNU ld toolchain causes issues with relocation symbols and truncations.