### PR TITLE
weakref is not included in test[limited]api in 3.15

### DIFF
--- a/cpython-unix/extension-modules.yml
+++ b/cpython-unix/extension-modules.yml
@@ -724,6 +724,7 @@ _testcapi:
       minimum-python-version: "3.12"
     - source: _testcapi/weakref.c
       minimum-python-version: "3.13"
+      maximum-python-version: "3.14"
 
 _testexternalinspection:
   minimum-python-version: '3.13'
@@ -798,6 +799,7 @@ _testlimitedcapi:
       minimum-python-version: "3.14"
     - source: _testlimitedcapi/weakref.c
       minimum-python-version: "3.13"
+      maximum-python-version: "3.14"
 
 _testmultiphase:
   minimum-python-version: '3.10'


### PR DESCRIPTION
A maximum python version was not added when this file was added in #1146.
This will likely need to be removed or reverted when the next beta of 3.15 is released.