### PR TITLE
safely remove PYTHON* env variables in distribution tests

### DIFF
--- a/pythonbuild/testdist.py
+++ b/pythonbuild/testdist.py
@@ -28,7 +28,7 @@ def run_dist_python(
     env = dict(os.environ)
 
     # Wipe PYTHON environment variables.
-    for k in env:
+    for k in list(env):
         if k.startswith("PYTHON"):
             del env[k]
 


### PR DESCRIPTION
Safely remove PYTHON* environment variables when running the distibution tests.

Since the env dictionary is mutated within the loop a copy must be made.