### PR TITLE
Retain embedded ZipFS data in Tcl/Tk DLLs on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -186,4 +186,7 @@ jobs:
         run: |
           $Dists = Resolve-Path -Path "dist/*.tar.zst" -Relative
           .\pythonbuild.exe validate-distribution $Dists
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
           uv run --no-dev test-distribution.py $Dists

--- a/src/release.rs
+++ b/src/release.rs
@@ -636,9 +636,12 @@ pub fn convert_to_stripped<W: Write>(
                 | FileKind::Pe32
                 | FileKind::Pe64)
         ) {
-            // Skip stripping MSVC runtime DLLs
+            // Skip stripping MSVC runtime DLLs and Tcl/Tk DLLs containing ZIPFS data.
             let filename = path.file_name().and_then(|n| n.to_str());
-            if !matches!(filename, Some("vcruntime140.dll" | "vcruntime140_1.dll")) {
+            if !matches!(
+                filename,
+                Some("tcl90.dll" | "tcl9tk90.dll" | "vcruntime140.dll" | "vcruntime140_1.dll")
+            ) {
                 data = llvm_strip(&data, llvm_dir)
                     .with_context(|| format!("failed to strip {}", path.display()))?;
             }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -151,6 +151,11 @@ const PE_ALLOWED_LIBRARIES_315: &[&str] = &[
     "zlib1.dll",
     "api-ms-win-crt-private-l1-1-0.dll",
     "msvcrt.dll",
+    // Tcl/Tk 9 is used in CPython 3.15+
+    "libtommath.dll",
+    "tcl90.dll",
+    "tcl9tk90.dll",
+    "WINSPOOL.DRV",
     // `_remote_debugging` loads `ntdll`
     // See https://github.com/python/cpython/pull/138710
     "ntdll.dll",


### PR DESCRIPTION
Do not strip the tcl90.dll and tcl9tk90.dll DLLs in the Windows distribution (which are now allowed) as they contained embedded versions of the Tcl and Tk library as ZipFS data that are required at runtime for Tkinter to work correctly.

Currently this is limited to CPython 3.15 as this is the only version that uses Tcl/Tk 9.0 on Windows. This may change if support for Tcl/Tk 9.0 is backported. 

Also update the Windows GitHub action to eheck the error code after the validate-distribution is run and end early if needed.

See https://github.com/actions/runner-images/issues/6668