### PR TITLE
Enable os.getrandom with modern Linux UAPI headers

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -318,6 +318,19 @@ fi
 # from that header. Include it whenever configure finds the header.
 patch -p1 -i "${ROOT}/patch-posixmodule-sys-syscall-header.patch"
 
+# Older glibc headers do not define SYS_getrandom even when the modern UAPI
+# headers provide __NR_getrandom. Use the UAPI syscall number directly so
+# CPython can compile os.getrandom without raising the minimum glibc version.
+if [[ -n "${LINUX_UAPI_INCLUDE_ARCH:-}" ]]; then
+    if [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_15}" ]]; then
+        patch -p1 -i "${ROOT}/patch-getrandom-use-nr-3.15.patch"
+    elif [[ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" ]]; then
+        patch -p1 -i "${ROOT}/patch-getrandom-use-nr-3.14.patch"
+    else
+        patch -p1 -i "${ROOT}/patch-getrandom-use-nr-3.12.patch"
+    fi
+fi
+
 # Most bits look at CFLAGS. But setup.py only looks at CPPFLAGS.
 # So we need to set both.
 CFLAGS="${EXTRA_TARGET_CFLAGS} -fPIC -I${TOOLS_PATH}/deps/include -I${TOOLS_PATH}/deps/include/ncursesw"

--- a/cpython-unix/patch-getrandom-use-nr-3.12.patch
+++ b/cpython-unix/patch-getrandom-use-nr-3.12.patch
@@ -1,0 +1,21 @@
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -6990 +6990 @@
+-        (void)syscall(SYS_getrandom, buffer, buflen, flags);
++        (void)syscall(__NR_getrandom, buffer, buflen, flags);
+diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
+--- a/Modules/posixmodule.c
++++ b/Modules/posixmodule.c
+@@ -15684 +15684 @@
+-        n = syscall(SYS_getrandom,
++        n = syscall(__NR_getrandom,
+diff --git a/Python/bootstrap_hash.c b/Python/bootstrap_hash.c
+--- a/Python/bootstrap_hash.c
++++ b/Python/bootstrap_hash.c
+@@ -129 +129 @@
+-            n = syscall(SYS_getrandom, dest, n, flags);
++            n = syscall(__NR_getrandom, dest, n, flags);
+@@ -133 +133 @@
+-            n = syscall(SYS_getrandom, dest, n, flags);
++            n = syscall(__NR_getrandom, dest, n, flags);

--- a/cpython-unix/patch-getrandom-use-nr-3.14.patch
+++ b/cpython-unix/patch-getrandom-use-nr-3.14.patch
@@ -1,0 +1,24 @@
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -7263 +7263 @@
+-        (void)syscall(SYS_getrandom, buffer, buflen, flags);
++        (void)syscall(__NR_getrandom, buffer, buflen, flags);
+diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
+--- a/Modules/posixmodule.c
++++ b/Modules/posixmodule.c
+@@ -16559 +16559 @@
+-        n = syscall(SYS_getrandom,
++        n = syscall(__NR_getrandom,
+diff --git a/Python/bootstrap_hash.c b/Python/bootstrap_hash.c
+--- a/Python/bootstrap_hash.c
++++ b/Python/bootstrap_hash.c
+@@ -25 +25 @@
+-#    include <sys/syscall.h>      // SYS_getrandom
++#    include <sys/syscall.h>      // __NR_getrandom
+@@ -133 +133 @@
+-            n = syscall(SYS_getrandom, dest, n, flags);
++            n = syscall(__NR_getrandom, dest, n, flags);
+@@ -137 +137 @@
+-            n = syscall(SYS_getrandom, dest, n, flags);
++            n = syscall(__NR_getrandom, dest, n, flags);

--- a/cpython-unix/patch-getrandom-use-nr-3.15.patch
+++ b/cpython-unix/patch-getrandom-use-nr-3.15.patch
@@ -1,0 +1,24 @@
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -7689 +7689 @@
+-        (void)syscall(SYS_getrandom, buffer, buflen, flags);
++        (void)syscall(__NR_getrandom, buffer, buflen, flags);
+diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
+--- a/Modules/posixmodule.c
++++ b/Modules/posixmodule.c
+@@ -17258 +17258 @@
+-        n = syscall(SYS_getrandom, data, size, flags);
++        n = syscall(__NR_getrandom, data, size, flags);
+diff --git a/Python/bootstrap_hash.c b/Python/bootstrap_hash.c
+--- a/Python/bootstrap_hash.c
++++ b/Python/bootstrap_hash.c
+@@ -26 +26 @@
+-#    include <sys/syscall.h>      // SYS_getrandom
++#    include <sys/syscall.h>      // __NR_getrandom
+@@ -134 +134 @@
+-            n = syscall(SYS_getrandom, dest, n, flags);
++            n = syscall(__NR_getrandom, dest, n, flags);
+@@ -138 +138 @@
+-            n = syscall(SYS_getrandom, dest, n, flags);
++            n = syscall(__NR_getrandom, dest, n, flags);

--- a/pythonbuild/disttests/__init__.py
+++ b/pythonbuild/disttests/__init__.py
@@ -361,6 +361,24 @@ class TestPythonInterpreter(unittest.TestCase):
 
     @unittest.skipUnless(
         "-linux-gnu" in os.environ["TARGET_TRIPLE"],
+        "modern kernel UAPI headers are currently enabled for Linux GNU targets",
+    )
+    def test_os_getrandom(self):
+        import errno
+
+        self.assertTrue(hasattr(os, "getrandom"))
+
+        try:
+            data = os.getrandom(16)
+        except OSError as exc:
+            if exc.errno == errno.ENOSYS:
+                self.skipTest("the runtime kernel does not support getrandom")
+            raise
+
+        self.assertEqual(len(data), 16)
+
+    @unittest.skipUnless(
+        "-linux-gnu" in os.environ["TARGET_TRIPLE"],
         "memfd_create weak linking is enabled for Linux GNU targets",
     )
     def test_os_memfd_create(self):


### PR DESCRIPTION
Enable `os.getrandom` when building CPython against the modern Linux UAPI headers.

Older glibc versions do not define `SYS_getrandom` which is used for the `os.getrandom` implementation. Patch CPython to use `__NR_getrandom` which is defined in the UAPI headers. This make `os.getrandom` available in all builds.

This does not increase the minimum required glibc or runtime kernel version. If the running kernel does not support `getrandom`, the syscall returns `ENOSYS`, which Python exposes as `OSError`.

Related to #193.