### PR TITLE
Skip BOLT optimization for HACL hash compressors

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -495,7 +495,11 @@ if [ -n "${CPYTHON_OPTIMIZED}" ]; then
         # https://github.com/python/cpython/issues/128514
         # https://github.com/python/cpython/pull/134642
         # https://github.com/llvm/llvm-project/issues/174191
-        BOLT_COMMON_FLAGS="-update-debug-sections -skip-funcs=RC4_options/1"
+        # BOLT's allocation combiner can remove required stack allocations in
+        # the HACL hash compressors, leaving frame-pointer-relative accesses
+        # below the x86-64 red zone. Match BOLT's `/N` suffix for local symbols.
+        # https://github.com/astral-sh/uv/issues/20618
+        BOLT_COMMON_FLAGS="-update-debug-sections -skip-funcs=RC4_options/1,sha256_update/.*,sha512_update/.*,PyBlake2_blake2b_compress/.*,PyBlake2_blake2s_compress/.*,update_block.*"
         BOLT_APPLY_FLAGS="${BOLT_COMMON_FLAGS} \
 -reorder-blocks=ext-tsp \
 -reorder-functions=cdsort \


### PR DESCRIPTION
Optimized x86-64 GNU/Linux builds can perform invalid stack writes in the HACL SHA-2 and BLAKE2 compressors because BOLT's allocation combiner removes their required stack allocation while retaining frame-pointer-relative accesses below the red zone. Extend `-skip-funcs` for the affected compressor symbols so BOLT leaves these functions intact while continuing to optimize the rest of the interpreter.

See https://github.com/astral-sh/python-build-standalone/issues/1186
