### PR TITLE
Tcl/Tk 9.0.4 on Windows

### DIFF
--- a/cpython-windows/build.py
+++ b/cpython-windows/build.py
@@ -397,7 +397,7 @@ def hack_props(
     mpdecimal_version = DOWNLOADS["mpdecimal"]["version"]
 
     if meets_python_minimum_version(python_version, "3.15"):
-        tcltk_commit = DOWNLOADS["tk-windows-bin-903"]["git_commit"]
+        tcltk_commit = DOWNLOADS["tk-windows-bin-904"]["git_commit"]
     elif meets_python_minimum_version(python_version, "3.14") or arch == "arm64":
         tcltk_commit = DOWNLOADS["tk-windows-bin-8614"]["git_commit"]
     else:
@@ -1403,7 +1403,7 @@ def build_cpython(
     # is not available for arm64 so we use a newer release there as well.
     # On CPython 3.14+ we match the version included in the Python.org release.
     if meets_python_minimum_version(python_version, "3.15"):
-        tk_bin_entry = "tk-windows-bin-903"
+        tk_bin_entry = "tk-windows-bin-904"
     elif meets_python_minimum_version(python_version, "3.14") or arch == "arm64":
         tk_bin_entry = "tk-windows-bin-8614"
     else:
@@ -1513,7 +1513,7 @@ def build_cpython(
             shutil.copyfile(source, dest)
 
         # Delete the tk nmake helper, it's not needed and links msvc
-        if tk_bin_entry in ("tk-windows-bin-8614", "tk-windows-bin-903"):
+        if tk_bin_entry in ("tk-windows-bin-8614", "tk-windows-bin-904"):
             tcltk_commit: str = DOWNLOADS[tk_bin_entry]["git_commit"]
             tcltk_path = td / ("cpython-bin-deps-%s" % tcltk_commit)
             (

--- a/pythonbuild/downloads.py
+++ b/pythonbuild/downloads.py
@@ -342,12 +342,12 @@ DOWNLOADS = {
         "licenses": ["TCL"],
         "license_file": "LICENSE.tcl.txt",
     },
-    "tk-windows-bin-903": {
-        "url": "https://github.com/python/cpython-bin-deps/archive/2f788ebecac8d4bc3c7fa982b55a6c6923aa55fb.tar.gz",
-        "size": 18527780,
-        "sha256": "ac7e489d1fdabb0dbb69896aa8d191b5a87d053ce306fdffa51bbd77b94dbafc",
-        "version": "9.0.3",
-        "git_commit": "2f788ebecac8d4bc3c7fa982b55a6c6923aa55fb",
+    "tk-windows-bin-904": {
+        "url": "https://github.com/python/cpython-bin-deps/archive/907f3f4de820cb74fc8fb4431a39beae4c690915.tar.gz",
+        "size": 15632291,
+        "sha256": "e7aaa6417b7c2301ecd876307cced7e5bc4575a0b96e66dd08fcb6ab0d5d87a8",
+        "version": "9.0.4",
+        "git_commit": "907f3f4de820cb74fc8fb4431a39beae4c690915",
     },
     "tk-windows-bin-8614": {
         "url": "https://github.com/python/cpython-bin-deps/archive/c624cc881bd0e5071dec9de4b120cbe9985d8c14.tar.gz",

--- a/scripts/update_downloads.py
+++ b/scripts/update_downloads.py
@@ -403,7 +403,7 @@ UNSUPPORTED: dict[str, str] = {
     "tix": "source dependency snapshot",
     "tcl-8612": "legacy compatibility version",
     "tk-8612": "legacy compatibility version",
-    "tk-windows-bin-903": "commit-pinned CPython binary dependency",
+    "tk-windows-bin-904": "commit-pinned CPython binary dependency",
     "tk-windows-bin-8614": "commit-pinned CPython binary dependency",
     "tk-windows-bin-8612": "commit-pinned CPython binary dependency",
     "uuid": "inactive upstream project",


### PR DESCRIPTION
Update to the CPython provided Tcl/Tk 9.0.4 for 3.15+ on Windows.