### PR TITLE
Use Namespace runners for macOS builds

### DIFF
--- a/ci-runners.yaml
+++ b/ci-runners.yaml
@@ -10,7 +10,7 @@ depot-ubuntu-22.04-arm-4:
   platform: linux
   free: false
 
-depot-macos-latest:
+namespace-profile-macos-15:
   arch: aarch64
   platform: darwin
   free: false


### PR DESCRIPTION
Switch macOS `pythonbuild` crate and CPython distribution builds from Depot to the existing `namespace-profile-macos-15` runner profile through `ci-runners.yaml`. Preserve the existing shared matrix and runner configuration for other platforms.