### PR TITLE
Use a sparse checkout of the macOS SDKs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -171,6 +171,12 @@ jobs:
           repository: phracker/MacOSX-SDKs
           ref: master
           path: macosx-sdks
+          sparse-checkout: |
+            /MacOSX10.15.sdk/SDKSettings.json
+            /MacOSX10.15.sdk/**/*.tbd
+            /MacOSX11.*.sdk/SDKSettings.json
+            /MacOSX11.*.sdk/**/*.tbd
+          sparse-checkout-cone-mode: false
           persist-credentials: false
 
       - name: Validate Distribution


### PR DESCRIPTION
Use a sparse checkout of only the files needed during validations to speed up the checkout of the macOS SDKs repository.

A full check out typically takes between 2-3 minutes although occasionally the checkout can take much longer.