### PR TITLE
Bump pip from 26.2 -> 26.2.1

### DIFF
--- a/pythonbuild/downloads.py
+++ b/pythonbuild/downloads.py
@@ -287,10 +287,10 @@ DOWNLOADS = {
         "version": "0.13.1",
     },
     "pip": {
-        "url": "https://files.pythonhosted.org/packages/62/36/a3aed958d60531cb442b7ab4596cda7b3621cfb916f8ae1d6769795c7dc1/pip-26.2-py3-none-any.whl",
-        "size": 1816475,
-        "sha256": "931c303696af6fa3417112103b1cad26890e5a07eccb5b99783700e33f2b8aad",
-        "version": "26.2",
+        "url": "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl",
+        "size": 1816632,
+        "sha256": "71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e",
+        "version": "26.2.1",
     },
     "setuptools": {
         "url": "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl",


### PR DESCRIPTION
Comes with one bug fix for using keyring from a non-activated virtual environment when installing build dependencies