### PR TITLE
Enable static builds for the aarch64-linux-musl target

### DIFF
--- a/ci-targets.yaml
+++ b/ci-targets.yaml
@@ -360,10 +360,9 @@ linux:
       - "3.14"
       - "3.15"
     build_options:
-      # TODO: Static support is current blocked by some compiler-rt linking issues
-      # - debug+static
-      # - noopt+static
-      # - lto+static
+      - debug+static
+      - noopt+static
+      - lto+static
       - debug
       - noopt
       - lto

--- a/cpython-unix/build-musl.sh
+++ b/cpython-unix/build-musl.sh
@@ -105,4 +105,17 @@ CFLAGS="${CFLAGS}" CPPFLAGS="${CPPFLAGS}" ./configure \
 make -j "$(nproc)"
 make -j "$(nproc)" install DESTDIR=/build/out
 
+if [ -n "${STATIC}" ] && [[ "$(clang -dumpmachine)" == aarch64-* ]]; then
+    # musl's linker wrapper appends libc after other arguments, including
+    # compiler-rt supplied through the target compiler flags. On aarch64,
+    # static libc uses compiler runtime builtins such as __multf3. GNU ld
+    # searches archives left to right and does not revisit earlier archives,
+    # so append compiler-rt again after libc to resolve those symbols.
+    # TODO(jjh): Remove this adjustment when lld is available; it can resolve
+    # references to previously encountered archives.
+    sed -i \
+        's/"$@" -lc -dynamic-linker/"$@" -lc "$($cc --rtlib=compiler-rt -print-libgcc-file-name)" -dynamic-linker/' \
+        /build/out/tools/host/bin/ld.musl-clang
+fi
+
 popd

--- a/cpython-unix/build-musl.sh
+++ b/cpython-unix/build-musl.sh
@@ -105,7 +105,7 @@ CFLAGS="${CFLAGS}" CPPFLAGS="${CPPFLAGS}" ./configure \
 make -j "$(nproc)"
 make -j "$(nproc)" install DESTDIR=/build/out
 
-if [ -n "${STATIC}" ] && [[ "$(clang -dumpmachine)" == aarch64-* ]]; then
+if [[ $STATIC && $(clang -dumpmachine) == aarch64-* ]]; then
     # musl's linker wrapper appends libc after other arguments, including
     # compiler-rt supplied through the target compiler flags. On aarch64,
     # static libc uses compiler runtime builtins such as __multf3. GNU ld

--- a/cpython-unix/build.py
+++ b/cpython-unix/build.py
@@ -98,7 +98,9 @@ def add_target_env(env, build_platform, target_triple, build_env, build_options)
     extra_host_cflags = []
     extra_host_ldflags = []
 
-    # Add compiler-rt for aarch64-musl to resolve missing builtins
+    # aarch64 libgcc is built against glibc and initializes LSE atomics using
+    # __getauxval, which musl does not export.
+    # Use compiler-rt instead, which uses the public getauxval interface.
     if target_triple == "aarch64-unknown-linux-musl":
         extra_target_cflags.append("--rtlib=compiler-rt")
         extra_target_ldflags.append("--rtlib=compiler-rt")

--- a/src/release.rs
+++ b/src/release.rs
@@ -363,7 +363,7 @@ pub static RELEASE_TRIPLES: Lazy<BTreeMap<&'static str, TripleRelease>> = Lazy::
     h.insert(
         "aarch64-unknown-linux-musl",
         TripleRelease {
-            suffixes: vec!["debug", "lto", "noopt"],
+            suffixes: linux_suffixes_musl.clone(),
             install_only_suffix: "lto",
             freethreaded_install_only_suffix: "freethreaded+lto",
             python_version_requirement: None,


### PR DESCRIPTION
Enable static builds for the `aarch64-unknown-linux-musl` target.