### PR TITLE
skip llvm-strip on signed DLLs

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -636,11 +636,27 @@ pub fn convert_to_stripped<W: Write>(
                 | FileKind::Pe32
                 | FileKind::Pe64)
         ) {
-            // Skip stripping MSVC runtime DLLs and Tcl/Tk DLLs containing ZIPFS data.
+            // Skip stripping MSVC runtime DLLs and Tcl/Tk DLLs containing ZIPFS data or
+            // valid signatures.
+            // Tcl 9 DLLs contain ZIPFS data. The other DLLs are signed by Microsoft or by the
+            // Tcl maintainers. `llvm-strip` removes the signature but keeps
+            // the certificate table entry in the PE header.
+            // This makes the binaries impossible to re-sign with `signtool`, which in turn
+            // means that they can never be bundled into a Microsoft Store-compatible .msix.
             let filename = path.file_name().and_then(|n| n.to_str());
             if !matches!(
                 filename,
-                Some("tcl90.dll" | "tcl9tk90.dll" | "vcruntime140.dll" | "vcruntime140_1.dll")
+                Some(
+                    "tcl86t.dll"
+                        | "tcl90.dll"
+                        | "tcl9tk90.dll"
+                        | "tcldde14.dll"
+                        | "tclreg13.dll"
+                        | "tk86t.dll"
+                        | "vcruntime140.dll"
+                        | "vcruntime140_1.dll"
+                        | "vcruntime140_threads.dll"
+                )
             ) {
                 data = llvm_strip(&data, llvm_dir)
                     .with_context(|| format!("failed to strip {}", path.display()))?;


### PR DESCRIPTION
when packaging a `uv python` installed python into a .msix app for the microsoft app store, i hit some `signtool` failures with error `0x800700C1`. 

these are caused by `AppxSIP` going thru every binary in your package and validating them in some way.

`llvm-strip` removes the signature from a bunch of DLLs that come with these python buidls, but it keeps the certificate table entry in the PE optional header , which makes the entry point past the end of the file.

this is *exactly* the bug from https://github.com/astral-sh/python-build-standalone/issues/855 that https://github.com/astral-sh/python-build-standalone/pull/856 solved. i'm extending it to more DLLs and adding a comment explaining it.

a more permanent fix might be detecting signatures on files and skipping if we see them? let me know if you'd rather that, i could wireup detecting signatures and/or zipfs to get rid of the hardcoded list that'll probably regress as versions change what DLLs are shipped.